### PR TITLE
Bump MSRV to 1.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Further, it optionally supports parsing footnotes,
 [Github flavored task lists](https://github.github.com/gfm/#task-list-items-extension-) and
 [strikethrough](https://github.github.com/gfm/#strikethrough-extension-).
 
-Rustc 1.34 or newer is required to build the crate.
+Rustc 1.36 or newer is required to build the crate.
 
 ## Why a pull parser?
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pool:
 
 steps:
   - script: |
-      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.34.0
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.36.0
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     displayName: Install rust
   - script: cargo build --all


### PR DESCRIPTION
This allows us to use the `Iterator::copied` method (and should stop the azure builds from breaking).