### PR TITLE
Use correct `both` flag when pushing remaining delimiters to stack

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1248,3 +1248,20 @@ Table interruption when nested inside paragraph.
 </tbody></table>
 </blockquote>
 ````````````````````````````````
+
+
+ISSUE 657
+
+```````````````````````````````` example
+***R]*-*
+.
+<p>*<em><em>R]</em>-</em></p>
+````````````````````````````````
+
+The below example adds a trailing space.
+
+```````````````````````````````` example
+****foo*bar*baz****
+.
+<p><strong><em><em>foo</em>bar</em>baz</strong>**</p>
+````````````````````````````````

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -620,7 +620,7 @@ impl<'input, 'callback> Parser<'input, 'callback> {
                                     start: el.start,
                                     count: el.count - match_count,
                                     c: el.c,
-                                    both,
+                                    both: el.both,
                                 })
                             }
                             count -= match_count;

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -1481,3 +1481,23 @@ fn regression_test_98() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_99() {
+    let original = r##"***R]*-*
+"##;
+    let expected = r##"<p>*<em><em>R]</em>-</em></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_100() {
+    let original = r##"****foo*bar*baz****
+"##;
+    let expected = r##"<p><strong><em><em>foo</em>bar</em>baz</strong>**</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
Fixes #657

Here's the delimiter match-ups that pulldown-cmark made before this commit, annotated to make clear the both flag and the multiple-of-three matching that was erroneously applied:

    ****foo*bar*baz****
    ^^12   2   1   ^^^^ = 6
           -   - both

    ***R]*-*
    ^^1  1 ^ = 3
         - both