### PR TITLE
Math spec

### DIFF
--- a/specs/future/math.txt
+++ b/specs/future/math.txt
@@ -1,4 +1,4 @@
-Run this with `cargo run -- -M -s specs/math.txt`.
+Run this with `cargo test --features gen-tests suite::math`.
 
 Mathematical expressions extension. Syntax based on
 <https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/math.md>

--- a/specs/future/math.txt
+++ b/specs/future/math.txt
@@ -1,0 +1,251 @@
+Run this with `cargo run -- -M -s specs/math.txt`.
+
+Mathematical expressions extension. Syntax based on
+<https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/math.md>
+excluding the handling for balanced curly braces.
+
+Inline mode mathematical expressions:
+
+```````````````````````````````` example
+This sentence uses `$` delimiters to show math inline: $\sqrt{3x-1}+(1+x)^2$
+$\sum_{k=1}^n a_k b_k$: Mathematical expression at head of line
+
+`\` may follow just after the first `$`: $\{1, 2, 3\}$
+.
+<p>This sentence uses <code>$</code> delimiters to show math inline: <span class="math inline">\sqrt{3x-1}+(1+x)^2</span>
+<span class="math inline">\sum_{k=1}^n a_k b_k</span>: Mathematical expression at head of line</p>
+<p><code>\</code> may follow just after the first <code>$</code>: <span class="math inline">\{1, 2, 3\}</span>
+````````````````````````````````
+
+Display mode mathematical expressions:
+
+```````````````````````````````` example
+**The Cauchy-Schwarz Inequality**
+
+$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$
+.
+<p><strong>The Cauchy-Schwarz Inequality</strong></p>
+<p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)</span></p>
+````````````````````````````````
+
+Inline math expressions cannot be empty, but display mode expressions can.
+
+```````````````````````````````` example
+Oops empty $$ expression.
+
+$$$$
+.
+<p>Oops empty $$ expression.</p>
+<p><span class="math display"></span></p>
+````````````````````````````````
+
+Math expressions pass their content through as-is, ignoring any other inline
+Markdown constructs:
+
+```````````````````````````````` example
+$a<b>c</b>$
+
+$${a*b*c} _c_ d$$
+
+$not `code`$
+
+$![not an](/image)$
+
+$<https://not.a.link/>$
+
+$&alpha;$
+.
+<p><span class="math inline">a&lt;b&gt;c&lt;/b&gt;</span></p>
+<p><span class="math display">{a*b*c} _c_ d</span></p>
+<p><span class="math inline">not `code`</span></p>
+<p><span class="math inline">![not an](/image)</span></p>
+<p><span class="math inline">&lt;https://not.a.link/&gt;</span></p>
+<p><span class="math inline">&amp;alpha;</span></p>
+````````````````````````````````
+
+Sole `$` characters without a matching pair in the same block element
+are handled as normal text.
+
+```````````````````````````````` example
+Hello $world.
+
+Dollar at end of line$
+.
+<p>Hello $world.</p>
+<p>Dollar at end of line$</p>
+````````````````````````````````
+
+Mathematical expressions can continue across multiple lines:
+
+```````````````````````````````` example
+$5x + 2 =
+17$
+
+$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
+\left( \sum_{k=1}^n b_k^2 \right)$$
+.
+<p><span class="math inline">5x + 2 =
+17</span></p>
+<p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
+\left( \sum_{k=1}^n b_k^2 \right)</span></p>
+````````````````````````````````
+
+Markdown hard breaks are also not recognized inside math expressions:
+
+```````````````````````````````` example
+$not a\
+hard break  
+either$
+.
+<p><span class="math inline">not a\
+hard break  
+either</span></p>
+````````````````````````````````
+
+
+`$` character can be escaped with backslash in mathematical expressions:
+
+```````````````````````````````` example
+$\$$
+
+$$y = \$ x$$
+.
+<p><span class="math inline">\$</span></p>
+<p><span class="math display">y = \$ x</span></p>
+````````````````````````````````
+
+Inline mode math expressions cannot contain unescaped `$` characters, but
+display mode expressions can, though not two in a row:
+
+```````````````````````````````` example
+$x $ x$
+
+$$ $ $$
+
+$$ $$ $$
+.
+<p>$x $ x$</p>
+<p><span class="math display"> $ </span></p>
+<p><span class="math display"> </span> $$</p>
+````````````````````````````````
+
+Inline math expressions cannot start or end with whitespace, including newlines:
+
+```````````````````````````````` example
+these are not math texts: $ y=x$, $y=x $, $
+y=x$ and $y=x
+$
+.
+<p>these are not math texts: $ y=x$, $y=x $, $
+y=x$ and $y=x
+$</p>
+````````````````````````````````
+
+Inline math expressions do not need to be surrounded with whitespace:
+
+```````````````````````````````` example
+these are math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
+.
+<p>these are math texts: foo<span class="math inline">y=x</span>bar and <span class="math inline">y=x</span>bar and foo<span class="math inline">y=x</span> bar</p>
+````````````````````````````````
+
+Inline math expressions can be surrounded by punctuation:
+
+```````````````````````````````` example
+math texts: $x=y$! and $x=y$? and $x=y$: and $x=y$. and $x=y$"
+
+also math texts: !$x=y$! and ?$x=y$? and :$x=y$: and .$x=y$. and "$x=y$"
+
+braces: ($x=y$) [$x=y$] {$x=y$}
+.
+<p>math texts: <span class="math inline">x=y</span>! and <span class="math inline">x=y</span>? and <span class="math inline">x=y</span>: and <span class="math inline">x=y</span>. and <span class="math inline">x=y</span>&quot;</p>
+<p>also math texts: !<span class="math inline">x=y</span>! and ?<span class="math inline">x=y</span>? and :<span class="math inline">x=y</span>: and .<span class="math inline">x=y</span>. and &quot;<span class="math inline">x=y</span>&quot;</p>
+<p>braces: (<span class="math inline">x=y</span>) [<span class="math inline">x=y</span>] {<span class="math inline">x=y</span>}</p>
+````````````````````````````````
+
+Math expression as only item on a line:
+
+```````````````````````````````` example
+$x=y$
+.
+<p><span class="math inline">x=y</span></p>
+````````````````````````````````
+
+Math expressions can be immediately followed by other math expressions:
+
+```````````````````````````````` example
+$a$$b$
+
+$a$$$b$$
+
+$$a$$$b$
+
+$$a$$$$b$$
+.
+<p><span class="math inline">a</span><span class="math inline">b</span></p>
+<p><span class="math inline">a</span><span class="math display">b</span></p>
+<p><span class="math display">a</span><span class="math inline">b</span></p>
+<p><span class="math display">a</span><span class="math display">b</span></p>
+````````````````````````````````
+
+Both inline and display mode math expressions are inline elements with the same
+precedence as code spans. The leftmost valid element takes priority:
+
+```````````````````````````````` example
+$Inline `first$ then` code
+
+`Code $first` then$ inline
+
+$$ Display `first $$ then` code
+
+`Code $$ first` then $$ display
+.
+<p><span class="math inline">Inline `first</span> then` code</p>
+<p><code>Code $first</code> then$ inline</p>
+<p><span class="math display"> Display `first </span> then` code</p>
+<p><code>Code $$ first</code> then $$ display</p>
+````````````````````````````````
+
+Indicators of block structure take precedence over math expressions:
+
+```````````````````````````````` example
+$x + y - z$
+
+$x + y
+- z$
+
+$$ x + y
+> z $$
+.
+<p><span class="math inline">x + y - z</span></p>
+<p>$x + y</p>
+<ul>
+<li>z$</li>
+</ul>
+<p>$$ x + y</p>
+<blockquote>
+<p>z $$</p>
+</blockquote>
+````````````````````````````````
+
+This also means that math expressions cannot contain empty lines, since they
+start a new paragraph:
+
+```````````````````````````````` example
+$not
+
+math$
+
+$$
+not
+
+math
+$$
+.
+<p>$not</p>
+<p>math$</p>
+<p>$$
+not</p>
+<p>math
+$$</p>
+````````````````````````````````

--- a/specs/future/math.txt
+++ b/specs/future/math.txt
@@ -28,7 +28,7 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \
 <p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)</span></p>
 ````````````````````````````````
 
-Inline math expressions cannot be empty, but display mode expressions can.
+Neither inline nor display mode math expressions can be empty.
 
 ```````````````````````````````` example
 Oops empty $$ expression.
@@ -36,7 +36,7 @@ Oops empty $$ expression.
 $$$$
 .
 <p>Oops empty $$ expression.</p>
-<p><span class="math display"></span></p>
+<p>$$$$</p>
 ````````````````````````````````
 
 Math expressions pass their content through as-is, ignoring any other inline
@@ -61,6 +61,33 @@ $&alpha;$
 <p><span class="math inline">![not an](/image)</span></p>
 <p><span class="math inline">&lt;https://not.a.link/&gt;</span></p>
 <p><span class="math inline">&amp;alpha;</span></p>
+````````````````````````````````
+
+The content of math expressions is handled similarly to code spans, except
+newlines are preserved and stripping of a leading and trailing space is not
+done. Indentation on subsequent lines of math items is trimmed out.
+
+(The generated tests cannot currently enforce that whitespace is emitted correctly, but
+the behavior is illustrated here.)
+
+```````````````````````````````` example
+$\TeX % comment
+no longer active on this line$
+
+$$ surrounding spaces $$
+
+- $indentation
+  inside list
+     and extra$
+.
+<p><span class="math inline">\TeX % comment
+no longer active on this line</span></p>
+<p><span class="math display"> surrounding spaces </span></p>
+<ul>
+<li><span class="math inline">indentation
+inside list
+and extra</span></li>
+</ul>
 ````````````````````````````````
 
 Sole `$` characters without a matching pair in the same block element
@@ -103,7 +130,7 @@ either</span></p>
 ````````````````````````````````
 
 
-`$` character can be escaped with backslash in mathematical expressions:
+`$` character can be escaped with a backslash in mathematical expressions:
 
 ```````````````````````````````` example
 $\$$
@@ -120,12 +147,15 @@ display mode expressions can, though not two in a row:
 ```````````````````````````````` example
 $x $ x$
 
-$$ $ $$
+$x x$x x$
+
+alpha$$beta$gamma$$delta
 
 $$ $$ $$
 .
 <p>$x $ x$</p>
-<p><span class="math display"> $ </span></p>
+<p><span class="math inline">x x</span>x x$</p>
+<p>alpha<span class="math display">beta$gamma</span>delta</p>
 <p><span class="math display"> </span> $$</p>
 ````````````````````````````````
 
@@ -189,7 +219,8 @@ $$a$$$$b$$
 ````````````````````````````````
 
 Both inline and display mode math expressions are inline elements with the same
-precedence as code spans. The leftmost valid element takes priority:
+precedence as code spans. The leftmost valid element takes priority, in a
+greedy fashion:
 
 ```````````````````````````````` example
 $Inline `first$ then` code
@@ -199,11 +230,14 @@ $Inline `first$ then` code
 $$ Display `first $$ then` code
 
 `Code $$ first` then $$ display
+
+$x$$$$$$$y$$
 .
 <p><span class="math inline">Inline `first</span> then` code</p>
 <p><code>Code $first</code> then$ inline</p>
 <p><span class="math display"> Display `first </span> then` code</p>
 <p><code>Code $$ first</code> then $$ display</p>
+<p><span class="math inline">x</span>$$$<span class="math display">$y</span></p>
 ````````````````````````````````
 
 Indicators of block structure take precedence over math expressions:
@@ -248,4 +282,27 @@ $$
 not</p>
 <p>math
 $$</p>
+````````````````````````````````
+
+As with code spans, pipes are special when inside a table. Escaped pipes `\|`
+inside tables discard one backslash. An unescaped pipe breaks the table cell
+instead.
+
+```````````````````````````````` example
+| Name | Description |
+| ---- | ----------- |
+| Trio | $\begin{array}{l \| c \| r} a & b & c \end{array}$ |
+| More | $\| \\| \\\|$ |
+
+| Name | Description |
+| ---- | ----------- |
+| $not | math$       |
+.
+<table><thead><tr><th>Name</th><th>Description</th></tr></thead><tbody>
+<tr><td>Trio</td><td><span class="math inline">\begin{array}{l | c | r} a &amp; b &amp; c \end{array}</span></td></tr>
+<tr><td>More</td><td><span class="math inline">| \| \\|</span></td></tr>
+</tbody></table>
+<table><thead><tr><th>Name</th><th>Description</th></tr></thead><tbody>
+<tr><td>$not</td><td>math$</td></tr>
+</tbody></table>
 ````````````````````````````````


### PR DESCRIPTION
Opening this to discuss a spec for `$math$`.

I intend to write about the rationale for the decisions made in the initial spec written in this PR soon. EDIT: This is now written below.

For reference, my implementation of this spec lives in #622 / rhysd#1

---

## TODO

- [x] `commonmark-hs` does not accept empty display math `$$$$`. I suppose we don't need to either.
- [x] Escaped pipes inside tables should match the behavior of code spans.

---

## Motivation

Support for embedding LaTeX math markup in documents has been discussed for a while. There are two types of math items in LaTeX, "inline mode" and "display mode". Display mode renders larger and is put (centered) on its own row by default.

Most syntaxes have to be recognized by the parser in the same phase as e.g. code spans are parsed. Pre- or post-processing is not sufficient, which is why support has to be implemented in `pulldown-cmark` itself. Consider these cases (written in the plain `$...$` syntax):

```
1: $a*b*c$
2: $a<b>c$
3: `$example$`
```

Post-processing would not work properly for cases 1 and 2.

Case 3 highlights why pre-processing is problematic. You could try to evade this with heuristics, but not all cases can reasonably be covered that way.

## General syntax

A great overview of the existing syntaxes can be found [here](https://github.com/cben/mathdown/wiki/math-in-markdown).

The basic syntax proposed in this PR is `$...$` for inline math, `$$...$$` for display math.

The choice of syntax is (and has been) a topic of endless debate. My main arguments in favor of this syntax are that:
- it comes directly from TeX/LaTeX, so it is familiar to users that know them. (Though `\[...\]` is now preferred for display math in LaTeX.)
- it is very commonly supported across other markdown parsers (built-in or as a provided plugin), and sites and services that use them.
- it feels markdown-y in the sense that it is similar to e.g. emphasis and code spans. It also doesn't conflict with any existing markdown syntax.

The main argument against this syntax is that dollar characters may be used in existing documents where math isn't intended. This is mitigated somewhat by whitespace/flanking rules, discussed later.

It is also worth noting that math parsing will be optional in `pulldown-cmark`, not enabled by default. Personally, making the syntax more complicated only to avoid some existing false positives seems fraught, because it solves a (mostly) temporary problem at the expense of making the feature permanently less convenient. Not to mention the existing markdown content written for other parsers that already uses this syntax. 

### Alternatives

Some remarks on potential alternative syntaxes which I consider relevant bringing up here.

- ``$`...`$`` for inline mode
  
   To my understanding, this was initially used by GitLab. It is most prominently supported by GitHub and GitLab, though both now also support the `$...$` syntax.

   This is the only syntax that can *almost* be implemented in post-processing only: detect parsed code spans surrounded by `$` text.
  
   Almost, because CommonMark code spans don't preserve line breaks. TeX comments for example, are sensitive to line breaks.
   ```
   $`
   f(x) = % comment
   2x + 1
   `$
   ```
  (Escaping the dollars poses a minor problem, too. Currently the `pulldown-cmark` parser output does not distinguish between a freestanding `$` and an escaped `\$`.)

   I am not opposed to supporting this in addition to `$...$`, but it could be done in an external crate.

   [GitHub](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions) seems to refer to this as a cop-out for when the plain `$...$` syntax doesn't work for whatever reason (they parse math by post-processing). If we do things properly, it should essentially never be _necessary_ to use to ``$`...`$``.

- ```` ```math ```` blocks for display mode.

  This is quite simple to do in another crate or by the crate user directly.

- `\(...\)` for inline mode or `\[...\]` for display mode.

   These are both also supported in LaTeX, though `\(...\)` isn't very commonly used. They clash quite badly with how CommonMark allows escaping punctuation, so I'm not fond of them within markdown.

- `$$\n...\n$$` for display mode, mimicking fenced code blocks.
  
   It is very common in LaTeX to write a display mode math item all on one line:
   ```
   $$ f(x) = 2x + 1 $$
   ```
   Also refer to the Display Is Inline section below.

## Specifics

Given the choice to go with the `$...$` and `$$...$$` syntax, `commonmark-hs`'s math extension seems like a good place to loan specifics from. Some of it is described well in [its spec](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/math.md) as well. `commonmark-hs` with math support is available in Pandoc under the `commonmark+math` and `commonmark_x` modes.

### Surrounding rules for inline math

To avoid some false positives in inline math items, we require this:

> In inline math, the opening `$` must not be followed by a whitespace, and the closing `$` must not be preceeded by whitespace.
> ```
> This is not math: 2000$.
> And neither is this $ 4 $.
> Or this $4
> $.
> ```

Pandoc recently (?) transitioned to this slightly more refined version, which is also a viable option:

> The opening \$ must have a non-space character immediately to its right, while the closing \$ must have a non-space character immediately to its left, and must not be followed immediately by a digit. Thus, \$20,000 and \$30,000 won’t parse as math.

GitHub has some very inconsistent rules for this, which [I haven't been able to fully decipher](https://github.com/rhysd/pulldown-cmark/pull/1#discussion_r1306387622). Even if we aim for GitHub compatibility, I don't think we should replicate its rules exactly.

### Display Is Inline

Because of how display math is rendered centered as a block, one might assume that it should also be parsed as a block level item.

However, it is common in LaTeX to write even display math within paragraphs, as part of a sentence.

```
The equation $$ 2x + 1 = 0 $$ has one root.
```

TeX/LaTeX also does not support empty lines within display math, as they signify a paragraph change:

```
$$
causes

errors
$$
```

Therefore it actually makes sense to parse display mode math as inline items as well. This is also easier to implement: inline and display mode math can reuse much of the same parsing logic.

Display math has a tendency to be split across multiple lines more liberally than inline math, however. CommonMark has a principle that all syntax that indicates block structure has higher priority than inline items. This does mean that display math can be broken by certain syntax:
```
$$ f(x) = 2x
- 1 oops it's a list $$

$$
f(x)
=
oops it's a setext-style heading
$$
```

This can be annoying, but I think it's an acceptable tradeoff. `commonmark-hs` does this, and it's not *too* surprising because it follows the same principle that applies to e.g. code spans as well.

Pandoc's own markdown flavor (different from `commonmark-hs`) has the best of both worlds: display math is an inline element, but also isn't preempted by block level syntax. Actually the same applies for code spans and inline math in the Pandoc flavor as well.

If we were to only make display math special and parse it in the first phase, cases like these would break:

```
`x$$y` ... `x$$y`

$x$$y$ ... $x$$y$
```

So this is a wholesale deal: either all of the constructs are higher priority than block-level indicators, or none of them are.

What about special casing? If a paragraph were to only consist of one display math item, it is parsed as such in the first phase. Other kinds of display math items are parsed in the second phase. This is reminiscent of how HTML blocks work in CommonMark. The difference in behavior depending on subtle newline changes isn't so nice with this approach though, and HTML blocks already cause enough confusion.

```
Explainer in separate paragraph:

$$
parses
=
ok
$$

Explainer in same paragraph:
$$
setext
=
heading...
$$
```

### Nested braces

`commonmark-hs` recently also supports having `$`s within math items, as long as they are inside nested, balanced braces. (An escaped `\$` is not the same, because it would also be escaped in the LaTeX code, so rendered as a dollar symbol.)

```
$\text{math $x$ again}$
```

This is **not** proposed in this PR as it currently stands. I feel it adds complexity to the implementation for negligible gain. Dollars can generally be replaced by alternative syntax like `\( \) \[ \]`. After seeing #734, I am on the fence about this.

## Output

The markdown parser only needs to recognize where there are math items. Any further processing or compilation is not in scope for this proposal. It should be relatively easy for a user of the crate to map the resulting `Item::Math` to whatever HTML they please.

The default HTML rendering of math items is something we have to specify, however.

A common way to render LaTeX math in HTML is to do it on the browser side (MathJax/KaTeX). This is facilitated either by using heuristics to find `$...$/$$...$$` etc., or by having `<span>`s with special classes. Since we've already parsed the math items, it doesn't make sense to emit them back without semantics only to be parsed by another set of rules again. Spans with classes are likely going to be what most users want.

The choice of classes (`math inline`, `math display`) is a little arbitrary though. For the spec, I copied what Pandoc does in the "KaTeX" math emitting mode. I have no strong opinions on this.