### PR TITLE
Fix redundant imports.

### DIFF
--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -94,7 +94,7 @@ mod scanners;
 mod strings;
 mod tree;
 
-use std::{convert::TryFrom, fmt::Display};
+use std::fmt::Display;
 
 pub use crate::parse::{
     BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback, OffsetIter, Parser, RefDefs,

--- a/pulldown-cmark/src/scanners.rs
+++ b/pulldown-cmark/src/scanners.rs
@@ -20,8 +20,7 @@
 
 //! Scanners for fragments of CommonMark syntax
 
-use std::convert::TryInto;
-use std::{char, convert::TryFrom};
+use std::char;
 
 use crate::parse::HtmlScanGuard;
 pub(crate) use crate::puncttable::{is_ascii_punctuation, is_punctuation};

--- a/pulldown-cmark/src/strings.rs
+++ b/pulldown-cmark/src/strings.rs
@@ -1,5 +1,4 @@
-use std::borrow::{Borrow, Cow, ToOwned};
-use std::convert::{AsRef, TryFrom};
+use std::borrow::{Borrow, Cow};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;


### PR DESCRIPTION
A recent nightly has started generating warnings for some redundant imports. This removes those unnecessary imports.