### PR TITLE
Adjust documentation on custom attributes

### DIFF
--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -139,7 +139,7 @@ pub enum Tag<'a> {
     /// A heading, with optional identifier, classes and custom attributes.
     /// The identifier is prefixed with `#` and the last one in the attributes
     /// list is chosen, classes are prefixed with `.` and custom attributes
-    /// have no prefix and can optionally have a value (`myattr` o `myattr=myvalue`).
+    /// have no prefix and can optionally have a value (`myattr` or `myattr=myvalue`).
     Heading {
         level: HeadingLevel,
         id: Option<CowStr<'a>>,
@@ -426,12 +426,12 @@ bitflags::bitflags! {
         const ENABLE_SMART_PUNCTUATION = 1 << 5;
         /// Extension to allow headings to have ID and classes.
         ///
-        /// `# text { #id .class1 .class2 myattr, other_attr=myvalue }`
+        /// `# text { #id .class1 .class2 myattr other_attr=myvalue }`
         /// is interpreted as a level 1 heading
         /// with the content `text`, ID `id`, classes `class1` and `class2` and
         /// custom attributes `myattr` (without value) and
         /// `other_attr` with value `myvalue`.
-        /// Note that attributes (ID and classes) should be space-separated.
+        /// Note that ID, classes, and custom attributes should be space-separated.
         const ENABLE_HEADING_ATTRIBUTES = 1 << 6;
         /// Metadata blocks in YAML style, i.e.:
         /// - starting with a `---` line


### PR DESCRIPTION
The docs seem to mistakenly show comma-separated custom heading attributes:

https://github.com/pulldown-cmark/pulldown-cmark/blob/4ba4738224a84de7447dbf85de7433f86caee15d/pulldown-cmark/src/lib.rs#L429

The actual behavior of the library, as verified by the tests, is to space-separate custom attributes:

https://github.com/pulldown-cmark/pulldown-cmark/blob/4ba4738224a84de7447dbf85de7433f86caee15d/pulldown-cmark/tests/suite/heading_attrs.rs#L14