### PR TITLE
perf: cargo-wizard default recommendations for runtime perf

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Ctarget-cpu=native"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Ctarget-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 members = ["pulldown-cmark", "pulldown-cmark-escape"]
 resolver = "2"
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/README.md
+++ b/README.md
@@ -176,9 +176,23 @@ Or add the feature to your project's `Cargo.toml`:
 pulldown-cmark = { version = "0.9.2", default-features = false, features = ["simd"] }
 ```
 
+For a higher release performance you may want this configuration in your profile release:
+
+```
+lto = true
+codegen-units = 1
+panic = "abort"
+```
+
 ## Authors
 
-The main author is Raph Levien. The implementation of the new design (v0.3+) was completed by Marcus Klaas de Vries.
+The main author is Raph Levien. The implementation of the new design (v0.3+) was
+completed by Marcus Klaas de Vries. Since 2023, the development has been driven
+by Martín Pozo, Michael Howell, Roope Salmi and Martin Geisler.
+
+## License
+
+This software is under the MIT license. See details in [license file](./LICENSE).
 
 ## Contributions
 


### PR DESCRIPTION
I just have added the default recommendations of cargo-wizard for runtime performance. The bench results are worthy, and I think these changes have not any inconvenience, but please confirm. I think that releasing a 0.10.1 version is also worthy.

Bench results (gnuplot errors omitted):

```
     Running benches/html_rendering.rs (/home/martin/Martín/Proyectos/pulldown-cmark/target/release/deps/html_rendering-6cadff3863e2afa1)
crdt_total              time:   [213.82 µs 214.47 µs 215.27 µs]
                        change: [-1.8691% -1.4872% -0.9837%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe

crdt_html               time:   [93.051 µs 93.524 µs 94.193 µs]
                        change: [+6.7202% +7.3571% +7.9703%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  7 (7.00%) high severe

crdt_all_options_parse  time:   [177.28 µs 177.33 µs 177.41 µs]
                        change: [-6.8583% -6.1637% -5.5163%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) high mild
  12 (12.00%) high severe

crdt_parse              time:   [145.17 µs 145.21 µs 145.25 µs]
                        change: [-6.4618% -6.2423% -6.0606%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe

smart_punctuation       time:   [1.6504 µs 1.6620 µs 1.6766 µs]
                        change: [-5.8442% -3.9119% -2.3603%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

links_n_emphasis        time:   [2.2594 µs 2.2623 µs 2.2661 µs]
                        change: [-12.994% -12.200% -11.470%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  4 (4.00%) high mild
  15 (15.00%) high severe

unescapes               time:   [7.9123 µs 7.9204 µs 7.9310 µs]
                        change: [-5.4202% -4.5376% -3.7053%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  13 (13.00%) high severe

autolinks_n_html        time:   [2.7974 µs 2.8050 µs 2.8138 µs]
                        change: [-9.6397% -9.4972% -9.3329%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  12 (12.00%) high severe

     Running benches/lib.rs (/home/martin/Martín/Proyectos/pulldown-cmark/target/release/deps/lib-998fcef44f66db8a)
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /1
                        time:   [371.61 µs 372.01 µs 372.64 µs]
                        thrpt:  [1.7966 MiB/s 1.7996 MiB/s 1.8016 MiB/s]
                 change:
                        time:   [-6.8855% -6.0589% -5.3193%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6181% +6.4496% +7.3946%]
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  5 (5.00%) high mild
  16 (16.00%) high severe

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /2: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.4s, enable flat sampling, or reduce sample count to 50.
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /2
                        time:   [1.4666 ms 1.4688 ms 1.4725 ms]
                        thrpt:  [929.80 KiB/s 932.14 KiB/s 933.57 KiB/s]
                 change:
                        time:   [-8.5668% -7.8500% -7.1993%] (p = 0.00 < 0.05)
                        thrpt:  [+7.7578% +8.5187% +9.3694%]
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) high mild
  19 (19.00%) high severe


Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /3
                        time:   [3.3143 ms 3.3529 ms 3.4009 ms]
                        thrpt:  [603.58 KiB/s 612.22 KiB/s 619.35 KiB/s]
                 change:
                        time:   [-6.6141% -5.4581% -4.0107%] (p = 0.00 < 0.05)
                        thrpt:  [+4.1783% +5.7732% +7.0825%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe


Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /4
                        time:   [5.9029 ms 5.9190 ms 5.9384 ms]
                        thrpt:  [460.78 KiB/s 462.30 KiB/s 463.56 KiB/s]
                 change:
                        time:   [-6.5944% -6.0811% -5.5875%] (p = 0.00 < 0.05)
                        thrpt:  [+5.9182% +6.4749% +7.0599%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) low mild
  6 (6.00%) high mild
  5 (5.00%) high severe


Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /5
                        time:   [9.2879 ms 9.2973 ms 9.3067 ms]
                        thrpt:  [367.47 KiB/s 367.84 KiB/s 368.21 KiB/s]
                 change:
                        time:   [-7.2072% -6.6863% -6.1931%] (p = 0.00 < 0.05)
                        thrpt:  [+6.6020% +7.1654% +7.7670%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /6
                        time:   [9.7680 ms 9.7851 ms 9.8078 ms]
                        thrpt:  [418.40 KiB/s 419.36 KiB/s 420.10 KiB/s]
                 change:
                        time:   [-6.2008% -5.3351% -4.6301%] (p = 0.00 < 0.05)
                        thrpt:  [+4.8549% +5.6358% +6.6108%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /7
                        time:   [9.7624 ms 9.7801 ms 9.7993 ms]
                        thrpt:  [488.52 KiB/s 489.47 KiB/s 490.36 KiB/s]
                 change:
                        time:   [-5.7337% -5.3075% -4.9338%] (p = 0.00 < 0.05)
                        thrpt:  [+5.1898% +5.6050% +6.0825%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /8
                        time:   [9.8037 ms 9.8221 ms 9.8414 ms]
                        thrpt:  [555.89 KiB/s 556.98 KiB/s 558.03 KiB/s]
                 change:
                        time:   [-4.9927% -4.7844% -4.5824%] (p = 0.00 < 0.05)
                        thrpt:  [+4.8025% +5.0248% +5.2551%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild


Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /9
                        time:   [9.8645 ms 9.8700 ms 9.8754 ms]
                        thrpt:  [623.19 KiB/s 623.53 KiB/s 623.88 KiB/s]
                 change:
                        time:   [-4.4787% -4.2281% -4.0345%] (p = 0.00 < 0.05)
                        thrpt:  [+4.2041% +4.4148% +4.6887%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild


Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /10
                        time:   [9.8169 ms 9.8281 ms 9.8411 ms]
                        thrpt:  [694.83 KiB/s 695.75 KiB/s 696.55 KiB/s]
                 change:
                        time:   [-5.2883% -5.0386% -4.8425%] (p = 0.00 < 0.05)
                        thrpt:  [+5.0889% +5.3059% +5.5835%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /11
                        time:   [9.7216 ms 9.7332 ms 9.7450 ms]
                        thrpt:  [771.83 KiB/s 772.77 KiB/s 773.69 KiB/s]
                 change:
                        time:   [-8.9041% -8.0971% -7.3757%] (p = 0.00 < 0.05)
                        thrpt:  [+7.9630% +8.8105% +9.7744%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /12
                        time:   [9.7793 ms 9.7920 ms 9.8053 ms]
                        thrpt:  [836.80 KiB/s 837.94 KiB/s 839.03 KiB/s]
                 change:
                        time:   [-7.2927% -6.5630% -5.9424%] (p = 0.00 < 0.05)
                        thrpt:  [+6.3178% +7.0240% +7.8663%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /13
                        time:   [9.8194 ms 9.8322 ms 9.8454 ms]
                        thrpt:  [902.82 KiB/s 904.04 KiB/s 905.21 KiB/s]
                 change:
                        time:   [-7.1939% -6.7167% -6.2747%] (p = 0.00 < 0.05)
                        thrpt:  [+6.6948% +7.2004% +7.7516%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /14
                        time:   [9.8677 ms 9.8936 ms 9.9266 ms]
                        thrpt:  [964.31 KiB/s 967.53 KiB/s 970.06 KiB/s]
                 change:
                        time:   [-8.7711% -7.8557% -6.9748%] (p = 0.00 < 0.05)
                        thrpt:  [+7.4977% +8.5255% +9.6144%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe


Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /15
                        time:   [9.8514 ms 9.8810 ms 9.9277 ms]
                        thrpt:  [1.0088 MiB/s 1.0136 MiB/s 1.0167 MiB/s]
                 change:
                        time:   [-5.9971% -5.6086% -5.1354%] (p = 0.00 < 0.05)
                        thrpt:  [+5.4134% +5.9418% +6.3797%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /16
                        time:   [9.9061 ms 9.9167 ms 9.9275 ms]
                        thrpt:  [1.0761 MiB/s 1.0773 MiB/s 1.0784 MiB/s]
                 change:
                        time:   [-5.4096% -5.2966% -5.1947%] (p = 0.00 < 0.05)
                        thrpt:  [+5.4793% +5.5928% +5.7190%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /17
                        time:   [9.9814 ms 9.9936 ms 10.006 ms]
                        thrpt:  [1.1344 MiB/s 1.1358 MiB/s 1.1372 MiB/s]
                 change:
                        time:   [-4.3688% -4.0764% -3.8401%] (p = 0.00 < 0.05)
                        thrpt:  [+3.9935% +4.2496% +4.5684%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild


Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /18
                        time:   [10.007 ms 10.019 ms 10.031 ms]
                        thrpt:  [1.1981 MiB/s 1.1996 MiB/s 1.2010 MiB/s]
                 change:
                        time:   [-13.407% -11.770% -10.233%] (p = 0.00 < 0.05)
                        thrpt:  [+11.399% +13.341% +15.483%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild


Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
Benchmarking     pub fn pathological_missing_table_cells(c: &mut Criterion) {
    pub fn pathological_missing_table_cells(c: &mut Criterion) {
            /19
                        time:   [10.006 ms 10.016 ms 10.026 ms]
                        thrpt:  [1.2653 MiB/s 1.2665 MiB/s 1.2678 MiB/s]
                 change:
                        time:   [-5.3266% -5.1984% -5.0799%] (p = 0.00 < 0.05)
                        thrpt:  [+5.3517% +5.4834% +5.6263%]
                        Performance has improved.

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /1
                        time:   [38.203 µs 38.226 µs 38.261 µs]
                        thrpt:  [12.587 MiB/s 12.599 MiB/s 12.607 MiB/s]
                 change:
                        time:   [-8.6536% -7.7866% -6.9870%] (p = 0.00 < 0.05)
                        thrpt:  [+7.5119% +8.4441% +9.4734%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) high mild
  11 (11.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /2
                        time:   [87.440 µs 87.446 µs 87.452 µs]
                        thrpt:  [10.960 MiB/s 10.960 MiB/s 10.961 MiB/s]
                 change:
                        time:   [-7.7687% -7.1882% -6.6887%] (p = 0.00 < 0.05)
                        thrpt:  [+7.1681% +7.7449% +8.4230%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /3
                        time:   [148.90 µs 148.93 µs 148.97 µs]
                        thrpt:  [9.6346 MiB/s 9.6376 MiB/s 9.6393 MiB/s]
                 change:
                        time:   [-9.7580% -8.6946% -7.8031%] (p = 0.00 < 0.05)
                        thrpt:  [+8.4635% +9.5226% +10.813%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /4
                        time:   [177.15 µs 177.22 µs 177.33 µs]
                        thrpt:  [10.783 MiB/s 10.790 MiB/s 10.794 MiB/s]
                 change:
                        time:   [-7.9053% -7.1622% -6.4695%] (p = 0.00 < 0.05)
                        thrpt:  [+6.9170% +7.7147% +8.5839%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe


Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /5
                        time:   [195.53 µs 195.61 µs 195.79 µs]
                        thrpt:  [12.202 MiB/s 12.213 MiB/s 12.218 MiB/s]
                 change:
                        time:   [-7.3041% -6.9109% -6.6402%] (p = 0.00 < 0.05)
                        thrpt:  [+7.1124% +7.4240% +7.8797%]
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  8 (8.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /6
                        time:   [216.10 µs 216.17 µs 216.27 µs]
                        thrpt:  [13.251 MiB/s 13.257 MiB/s 13.262 MiB/s]
                 change:
                        time:   [-6.3799% -6.2874% -6.1975%] (p = 0.00 < 0.05)
                        thrpt:  [+6.6070% +6.7092% +6.8147%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /7
                        time:   [238.46 µs 238.57 µs 238.76 µs]
                        thrpt:  [14.000 MiB/s 14.011 MiB/s 14.017 MiB/s]
                 change:
                        time:   [-6.4001% -6.0201% -5.7323%] (p = 0.00 < 0.05)
                        thrpt:  [+6.0808% +6.4057% +6.8378%]
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  6 (6.00%) high mild
  13 (13.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /8
                        time:   [262.30 µs 262.39 µs 262.54 µs]
                        thrpt:  [14.548 MiB/s 14.556 MiB/s 14.561 MiB/s]
                 change:
                        time:   [-6.0230% -5.7254% -5.3716%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6765% +6.0731% +6.4090%]
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  11 (11.00%) high severe


Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /9
                        time:   [285.38 µs 286.29 µs 287.36 µs]
                        thrpt:  [14.951 MiB/s 15.007 MiB/s 15.055 MiB/s]
                 change:
                        time:   [-6.6092% -6.1436% -5.6475%] (p = 0.00 < 0.05)
                        thrpt:  [+5.9855% +6.5457% +7.0770%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /10
                        time:   [305.25 µs 305.33 µs 305.44 µs]
                        thrpt:  [15.627 MiB/s 15.633 MiB/s 15.637 MiB/s]
                 change:
                        time:   [-8.2227% -7.4100% -6.8984%] (p = 0.00 < 0.05)
                        thrpt:  [+7.4096% +8.0030% +8.9594%]
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  4 (4.00%) low mild
  4 (4.00%) high mild
  13 (13.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /11
                        time:   [330.19 µs 330.34 µs 330.54 µs]
                        thrpt:  [15.883 MiB/s 15.893 MiB/s 15.900 MiB/s]
                 change:
                        time:   [-10.454% -9.4397% -8.5000%] (p = 0.00 < 0.05)
                        thrpt:  [+9.2896% +10.424% +11.675%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe


Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /12
                        time:   [355.27 µs 355.81 µs 356.73 µs]
                        thrpt:  [16.054 MiB/s 16.095 MiB/s 16.120 MiB/s]
                 change:
                        time:   [-11.017% -9.5983% -8.2960%] (p = 0.00 < 0.05)
                        thrpt:  [+9.0465% +10.617% +12.382%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) low severe
  1 (1.00%) high mild
  14 (14.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /13
                        time:   [380.49 µs 380.89 µs 381.64 µs]
                        thrpt:  [16.255 MiB/s 16.287 MiB/s 16.304 MiB/s]
                 change:
                        time:   [-5.0706% -4.6613% -4.3665%] (p = 0.00 < 0.05)
                        thrpt:  [+4.5659% +4.8892% +5.3415%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe


Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /14
                        time:   [404.37 µs 404.48 µs 404.66 µs]
                        thrpt:  [16.509 MiB/s 16.516 MiB/s 16.521 MiB/s]
                 change:
                        time:   [-5.7663% -5.2222% -4.7379%] (p = 0.00 < 0.05)
                        thrpt:  [+4.9735% +5.5099% +6.1191%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  9 (9.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /15
                        time:   [423.94 µs 424.13 µs 424.37 µs]
                        thrpt:  [16.866 MiB/s 16.875 MiB/s 16.883 MiB/s]
                 change:
                        time:   [-12.781% -11.111% -9.5213%] (p = 0.00 < 0.05)
                        thrpt:  [+10.523% +12.500% +14.654%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  6 (6.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /16
                        time:   [449.21 µs 449.55 µs 450.01 µs]
                        thrpt:  [16.964 MiB/s 16.982 MiB/s 16.995 MiB/s]
                 change:
                        time:   [-8.5849% -7.5426% -6.6837%] (p = 0.00 < 0.05)
                        thrpt:  [+7.1625% +8.1580% +9.3911%]
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  12 (12.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /17
                        time:   [468.52 µs 468.73 µs 469.06 µs]
                        thrpt:  [17.292 MiB/s 17.304 MiB/s 17.312 MiB/s]
                 change:
                        time:   [-10.882% -9.9650% -9.0555%] (p = 0.00 < 0.05)
                        thrpt:  [+9.9571% +11.068% +12.210%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) high mild
  13 (13.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /18
                        time:   [493.19 µs 493.55 µs 494.00 µs]
                        thrpt:  [17.384 MiB/s 17.400 MiB/s 17.413 MiB/s]
                 change:
                        time:   [-11.213% -9.8068% -8.6429%] (p = 0.00 < 0.05)
                        thrpt:  [+9.4606% +10.873% +12.629%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) low mild
  8 (8.00%) high severe

Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
Benchmarking     pub fn pathological_link_def(c: &mut Criterion) {
    pub fn pathological_link_def(c: &mut Criterion) {
            /19
                        time:   [516.97 µs 517.32 µs 517.76 µs]
                        thrpt:  [17.507 MiB/s 17.522 MiB/s 17.534 MiB/s]
                 change:
                        time:   [-8.8730% -7.9170% -7.0578%] (p = 0.00 < 0.05)
                        thrpt:  [+7.5938% +8.5977% +9.7369%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  11 (11.00%) high severe


pathological_codeblocks1/1
                        time:   [348.67 ns 348.79 ns 348.94 ns]
                        thrpt:  [276.04 MiB/s 276.16 MiB/s 276.25 MiB/s]
                 change:
                        time:   [-10.977% -10.311% -9.6788%] (p = 0.00 < 0.05)
                        thrpt:  [+10.716% +11.496% +12.330%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) high mild
  9 (9.00%) high severe
pathological_codeblocks1/2
                        time:   [798.94 ns 799.22 ns 799.51 ns]
                        thrpt:  [360.23 MiB/s 360.36 MiB/s 360.49 MiB/s]
                 change:
                        time:   [-9.0531% -8.1978% -7.4400%] (p = 0.00 < 0.05)
                        thrpt:  [+8.0380% +8.9298% +9.9543%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
pathological_codeblocks1/3
                        time:   [1.2972 µs 1.2983 µs 1.2997 µs]
                        thrpt:  [442.47 MiB/s 442.93 MiB/s 443.32 MiB/s]
                 change:
                        time:   [-4.9096% -4.1096% -3.2565%] (p = 0.00 < 0.05)
                        thrpt:  [+3.3661% +4.2857% +5.1631%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
pathological_codeblocks1/4
                        time:   [1.8670 µs 1.8687 µs 1.8707 µs]
                        thrpt:  [511.83 MiB/s 512.39 MiB/s 512.84 MiB/s]
                 change:
                        time:   [-3.1212% -2.7633% -2.3368%] (p = 0.00 < 0.05)
                        thrpt:  [+2.3927% +2.8418% +3.2217%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
pathological_codeblocks1/5
                        time:   [2.4710 µs 2.4719 µs 2.4735 µs]
                        thrpt:  [580.26 MiB/s 580.63 MiB/s 580.85 MiB/s]
                 change:
                        time:   [-2.6190% -2.4469% -2.2403%] (p = 0.00 < 0.05)
                        thrpt:  [+2.2917% +2.5083% +2.6894%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high severe
pathological_codeblocks1/6
                        time:   [3.2462 µs 3.2512 µs 3.2589 µs]
                        thrpt:  [616.30 MiB/s 617.75 MiB/s 618.71 MiB/s]
                 change:
                        time:   [-2.5793% -2.3751% -2.1594%] (p = 0.00 < 0.05)
                        thrpt:  [+2.2071% +2.4329% +2.6476%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
pathological_codeblocks1/7
                        time:   [4.1023 µs 4.1062 µs 4.1134 µs]
                        thrpt:  [650.79 MiB/s 651.93 MiB/s 652.55 MiB/s]
                 change:
                        time:   [-3.0048% -2.4165% -2.0306%] (p = 0.00 < 0.05)
                        thrpt:  [+2.0727% +2.4763% +3.0978%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
Benchmarking pathological_codeblocks1/8: Warming up for 3.0000 sthread 'main' panicked at pulldown-cmark/src/firstpass.rs:944:38:
slice index starts at 3619 but ends at 3608
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

``` 