### PR TITLE
Change `write_to_html` to allow `fmt::Write`

### DIFF
--- a/pulldown-cmark-escape/src/lib.rs
+++ b/pulldown-cmark-escape/src/lib.rs
@@ -21,8 +21,8 @@
 //! Utility functions for HTML escaping. Only useful when building your own
 //! HTML renderer.
 
-use std::fmt::{Arguments, Write as FmtWrite};
-use std::io::{self, ErrorKind, Write};
+use std::fmt::{self, Arguments};
+use std::io::{self, Write};
 use std::str::from_utf8;
 
 #[rustfmt::skip]
@@ -46,20 +46,23 @@ static SINGLE_QUOTE_ESCAPE: &str = "&#x27;";
 /// `W: StrWrite`. Since we need the latter a lot, we choose to wrap
 /// `Write` types.
 #[derive(Debug)]
-pub struct WriteWrapper<W>(pub W);
+pub struct IoWriter<W>(pub W);
 
 /// Trait that allows writing string slices. This is basically an extension
 /// of `std::io::Write` in order to include `String`.
 pub trait StrWrite {
-    fn write_str(&mut self, s: &str) -> io::Result<()>;
+    type Error;
 
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()>;
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error>;
+    fn write_fmt(&mut self, args: Arguments) -> Result<(), Self::Error>;
 }
 
-impl<W> StrWrite for WriteWrapper<W>
+impl<W> StrWrite for IoWriter<W>
 where
     W: Write,
 {
+    type Error = io::Error;
+
     #[inline]
     fn write_str(&mut self, s: &str) -> io::Result<()> {
         self.0.write_all(s.as_bytes())
@@ -71,17 +74,42 @@ where
     }
 }
 
-impl StrWrite for String {
+/// This wrapper exists because we can't have both a blanket implementation
+/// for all types implementing `Write` and types of the for `&mut W` where
+/// `W: StrWrite`. Since we need the latter a lot, we choose to wrap
+/// `Write` types.
+#[derive(Debug)]
+pub struct FmtWriter<W>(pub W);
+
+impl<W> StrWrite for FmtWriter<W>
+where
+    W: fmt::Write,
+{
+    type Error = fmt::Error;
+
     #[inline]
-    fn write_str(&mut self, s: &str) -> io::Result<()> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.0.write_str(s)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, args: Arguments) -> fmt::Result {
+        self.0.write_fmt(args)
+    }
+}
+
+impl StrWrite for String {
+    type Error = fmt::Error;
+
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
         self.push_str(s);
         Ok(())
     }
 
     #[inline]
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()> {
-        // FIXME: translate fmt error to io error?
-        FmtWrite::write_fmt(self, args).map_err(|_| ErrorKind::Other.into())
+    fn write_fmt(&mut self, args: Arguments) -> fmt::Result {
+        fmt::Write::write_fmt(self, args)
     }
 }
 
@@ -89,19 +117,21 @@ impl<W> StrWrite for &'_ mut W
 where
     W: StrWrite,
 {
+    type Error = W::Error;
+
     #[inline]
-    fn write_str(&mut self, s: &str) -> io::Result<()> {
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         (**self).write_str(s)
     }
 
     #[inline]
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()> {
+    fn write_fmt(&mut self, args: Arguments) -> Result<(), Self::Error> {
         (**self).write_fmt(args)
     }
 }
 
 /// Writes an href to the buffer, escaping href unsafe bytes.
-pub fn escape_href<W>(mut w: W, s: &str) -> io::Result<()>
+pub fn escape_href<W>(mut w: W, s: &str) -> Result<(), W::Error>
 where
     W: StrWrite,
 {
@@ -171,7 +201,7 @@ static HTML_ESCAPES: [&str; 6] = ["", "&amp;", "&lt;", "&gt;", "&quot;", "&#39;"
 /// // This is not okay.
 /// //let not_ok = format!("<a title={value}>test</a>");
 /// ````
-pub fn escape_html<W: StrWrite>(w: W, s: &str) -> io::Result<()> {
+pub fn escape_html<W: StrWrite>(w: W, s: &str) -> Result<(), W::Error> {
     #[cfg(all(target_arch = "x86_64", feature = "simd"))]
     {
         simd::escape_html(w, s, &HTML_ESCAPE_TABLE)
@@ -200,7 +230,7 @@ pub fn escape_html<W: StrWrite>(w: W, s: &str) -> io::Result<()> {
 /// It should always be correct, but will produce larger output.
 ///
 /// </div>
-pub fn escape_html_body_text<W: StrWrite>(w: W, s: &str) -> io::Result<()> {
+pub fn escape_html_body_text<W: StrWrite>(w: W, s: &str) -> Result<(), W::Error> {
     #[cfg(all(target_arch = "x86_64", feature = "simd"))]
     {
         simd::escape_html(w, s, &HTML_BODY_TEXT_ESCAPE_TABLE)
@@ -211,7 +241,11 @@ pub fn escape_html_body_text<W: StrWrite>(w: W, s: &str) -> io::Result<()> {
     }
 }
 
-fn escape_html_scalar<W: StrWrite>(mut w: W, s: &str, table: &'static [u8; 256]) -> io::Result<()> {
+fn escape_html_scalar<W: StrWrite>(
+    mut w: W,
+    s: &str,
+    table: &'static [u8; 256],
+) -> Result<(), W::Error> {
     let bytes = s.as_bytes();
     let mut mark = 0;
     let mut i = 0;

--- a/pulldown-cmark-escape/src/lib.rs
+++ b/pulldown-cmark-escape/src/lib.rs
@@ -75,7 +75,7 @@ where
 }
 
 /// This wrapper exists because we can't have both a blanket implementation
-/// for all types implementing `Write` and types of the for `&mut W` where
+/// for all types implementing `io::Write` and types of the form `&mut W` where
 /// `W: StrWrite`. Since we need the latter a lot, we choose to wrap
 /// `Write` types.
 #[derive(Debug)]

--- a/pulldown-cmark/examples/event-filter.rs
+++ b/pulldown-cmark/examples/event-filter.rs
@@ -1,6 +1,6 @@
 use std::io::Write as _;
 
-use pulldown_cmark::{html, Event, IoWriter, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{html, Event, Options, Parser, Tag, TagEnd};
 
 fn main() {
     let markdown_input: &str = "This is Peter on ![holiday in Greece](pearl_beach.jpg).";
@@ -8,21 +8,20 @@ fn main() {
 
     // Set up parser. We can treat is as any other iterator. We replace Peter by John
     // and image by its alt text.
-    let parser =
-        Parser::new_ext(markdown_input, Options::empty())
-            .map(|event| match event {
-                Event::Text(text) => Event::Text(text.replace("Peter", "John").into()),
-                _ => event,
-            })
-            .filter(|event| match event {
-                Event::Start(Tag::Image { .. }) | Event::End(TagEnd::Image) => false,
-                _ => true,
-            });
+    let parser = Parser::new_ext(markdown_input, Options::empty())
+        .map(|event| match event {
+            Event::Text(text) => Event::Text(text.replace("Peter", "John").into()),
+            _ => event,
+        })
+        .filter(|event| match event {
+            Event::Start(Tag::Image { .. }) | Event::End(TagEnd::Image) => false,
+            _ => true,
+        });
 
     // Write to anything implementing the `Write` trait. This could also be a file
     // or network socket.
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     handle.write_all(b"\nHTML output:\n").unwrap();
-    html::write_html(IoWriter(&mut handle), parser).unwrap();
+    html::write_html_io(&mut handle, parser).unwrap();
 }

--- a/pulldown-cmark/examples/event-filter.rs
+++ b/pulldown-cmark/examples/event-filter.rs
@@ -1,6 +1,6 @@
 use std::io::Write as _;
 
-use pulldown_cmark::{html, Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{html, Event, IoWriter, Options, Parser, Tag, TagEnd};
 
 fn main() {
     let markdown_input: &str = "This is Peter on ![holiday in Greece](pearl_beach.jpg).";
@@ -8,20 +8,21 @@ fn main() {
 
     // Set up parser. We can treat is as any other iterator. We replace Peter by John
     // and image by its alt text.
-    let parser = Parser::new_ext(markdown_input, Options::empty())
-        .map(|event| match event {
-            Event::Text(text) => Event::Text(text.replace("Peter", "John").into()),
-            _ => event,
-        })
-        .filter(|event| match event {
-            Event::Start(Tag::Image { .. }) | Event::End(TagEnd::Image) => false,
-            _ => true,
-        });
+    let parser =
+        Parser::new_ext(markdown_input, Options::empty())
+            .map(|event| match event {
+                Event::Text(text) => Event::Text(text.replace("Peter", "John").into()),
+                _ => event,
+            })
+            .filter(|event| match event {
+                Event::Start(Tag::Image { .. }) | Event::End(TagEnd::Image) => false,
+                _ => true,
+            });
 
     // Write to anything implementing the `Write` trait. This could also be a file
     // or network socket.
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     handle.write_all(b"\nHTML output:\n").unwrap();
-    html::write_html(&mut handle, parser).unwrap();
+    html::write_html(IoWriter(&mut handle), parser).unwrap();
 }

--- a/pulldown-cmark/examples/footnote-rewrite.rs
+++ b/pulldown-cmark/examples/footnote-rewrite.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::io::Write as _;
 
-use pulldown_cmark::{html, CowStr, Event, IoWriter, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{html, CowStr, Event, Options, Parser, Tag, TagEnd};
 
 /// This example shows how to do footnotes as bottom-notes, in the style of GitHub.
 fn main() {
@@ -53,7 +53,7 @@ fn main() {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     handle.write_all(b"\nHTML output:\n").unwrap();
-    html::write_html(IoWriter(&mut handle), parser).unwrap();
+    html::write_html_io(&mut handle, parser).unwrap();
 
     // To make the footnotes look right, we need to sort them by their appearance order, not by
     // the in-tree order of their actual definitions. Unused items are omitted entirely.
@@ -88,8 +88,8 @@ fn main() {
         handle
             .write_all(b"<hr><ol class=\"footnotes-list\">\n")
             .unwrap();
-        html::write_html(
-            IoWriter(&mut handle),
+        html::write_html_io(
+            &mut handle,
             footnotes.into_iter().flat_map(|fl| {
                 // To write backrefs, the name needs kept until the end of the footnote definition.
                 let mut name = CowStr::from("");

--- a/pulldown-cmark/examples/footnote-rewrite.rs
+++ b/pulldown-cmark/examples/footnote-rewrite.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::io::Write as _;
 
-use pulldown_cmark::{html, CowStr, Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{html, CowStr, Event, IoWriter, Options, Parser, Tag, TagEnd};
 
 /// This example shows how to do footnotes as bottom-notes, in the style of GitHub.
 fn main() {
@@ -53,7 +53,7 @@ fn main() {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     handle.write_all(b"\nHTML output:\n").unwrap();
-    html::write_html(&mut handle, parser).unwrap();
+    html::write_html(IoWriter(&mut handle), parser).unwrap();
 
     // To make the footnotes look right, we need to sort them by their appearance order, not by
     // the in-tree order of their actual definitions. Unused items are omitted entirely.
@@ -89,7 +89,7 @@ fn main() {
             .write_all(b"<hr><ol class=\"footnotes-list\">\n")
             .unwrap();
         html::write_html(
-            &mut handle,
+            IoWriter(&mut handle),
             footnotes.into_iter().flat_map(|fl| {
                 // To write backrefs, the name needs kept until the end of the footnote definition.
                 let mut name = CowStr::from("");

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -101,6 +101,7 @@ pub use crate::parse::{
 };
 pub use crate::strings::{CowStr, InlineStr};
 pub use crate::utils::*;
+pub use pulldown_cmark_escape::{FmtWriter, IoWriter, StrWrite};
 
 /// Codeblock kind.
 #[derive(Clone, Debug, PartialEq)]

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -101,7 +101,6 @@ pub use crate::parse::{
 };
 pub use crate::strings::{CowStr, InlineStr};
 pub use crate::utils::*;
-pub use pulldown_cmark_escape::{FmtWriter, IoWriter, StrWrite};
 
 /// Codeblock kind.
 #[derive(Clone, Debug, PartialEq)]

--- a/pulldown-cmark/src/main.rs
+++ b/pulldown-cmark/src/main.rs
@@ -22,7 +22,7 @@
 
 #![forbid(unsafe_code)]
 
-use pulldown_cmark::{html, BrokenLink, Options, Parser};
+use pulldown_cmark::{html, BrokenLink, IoWriter, Options, Parser};
 
 use std::env;
 use std::fs::File;
@@ -94,13 +94,14 @@ pub fn main() -> std::io::Result<()> {
         "fail if input file has broken links",
     );
 
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => {
-            eprintln!("{}\n{}", f, opts.usage(&brief(&args[0])));
-            std::process::exit(1);
-        }
-    };
+    let matches =
+        match opts.parse(&args[1..]) {
+            Ok(m) => m,
+            Err(f) => {
+                eprintln!("{}\n{}", f, opts.usage(&brief(&args[0])));
+                std::process::exit(1);
+            }
+        };
     if matches.opt_present("help") {
         println!("{}", opts.usage(&brief(&args[0])));
         return Ok(());
@@ -187,5 +188,5 @@ pub fn pulldown_cmark(input: &str, opts: Options, broken_links: &mut Vec<BrokenL
     );
     let stdio = io::stdout();
     let buffer = std::io::BufWriter::with_capacity(1024 * 1024, stdio.lock());
-    let _ = html::write_html(buffer, &mut p);
+    let _ = html::write_html(IoWriter(buffer), &mut p);
 }

--- a/pulldown-cmark/src/main.rs
+++ b/pulldown-cmark/src/main.rs
@@ -22,7 +22,7 @@
 
 #![forbid(unsafe_code)]
 
-use pulldown_cmark::{html, BrokenLink, IoWriter, Options, Parser};
+use pulldown_cmark::{html, BrokenLink, Options, Parser};
 
 use std::env;
 use std::fs::File;
@@ -94,14 +94,13 @@ pub fn main() -> std::io::Result<()> {
         "fail if input file has broken links",
     );
 
-    let matches =
-        match opts.parse(&args[1..]) {
-            Ok(m) => m,
-            Err(f) => {
-                eprintln!("{}\n{}", f, opts.usage(&brief(&args[0])));
-                std::process::exit(1);
-            }
-        };
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => {
+            eprintln!("{}\n{}", f, opts.usage(&brief(&args[0])));
+            std::process::exit(1);
+        }
+    };
     if matches.opt_present("help") {
         println!("{}", opts.usage(&brief(&args[0])));
         return Ok(());
@@ -188,5 +187,5 @@ pub fn pulldown_cmark(input: &str, opts: Options, broken_links: &mut Vec<BrokenL
     );
     let stdio = io::stdout();
     let buffer = std::io::BufWriter::with_capacity(1024 * 1024, stdio.lock());
-    let _ = html::write_html(IoWriter(buffer), &mut p);
+    let _ = html::write_html_io(buffer, &mut p);
 }


### PR DESCRIPTION
Previous attempt:
- https://github.com/pulldown-cmark/pulldown-cmark/pull/493

In this version I've just added an associated type on `StrWrite` so that `io::Error` isn't lost. Let me know if that makes sense.

Other alternatives: Instead of exposing `StrWrite`, `IoWriter` and `FmtWriter` we can expose two functions: `write_html_io` and `write_html_fmt` that accept `io::Write` and `fmt::Write` (`push_html` can be removed then).

~NOTE. This is a breaking change (should this PR bump version?)~ Changed base to 0.11