### PR TITLE
[0.11] Don't exit `scan_attribute` with the ix pointing at block quote

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2511,3 +2511,17 @@ ISSUE 853
 .
 <p><a href="((()))">linky</a></p>
 ````````````````````````````````
+
+ISSUE 857
+
+```````````````````````````````` example
+><span
+title
+>junk
+.
+<blockquote>
+<p>&lt;span
+title
+junk</p>
+</blockquote>
+````````````````````````````````

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3000,3 +3000,19 @@ fn regression_test_189() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_190() {
+    let original = r##"><span
+title
+>junk
+"##;
+    let expected = r##"<blockquote>
+<p>&lt;span
+title
+junk</p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
This is https://github.com/pulldown-cmark/pulldown-cmark/pull/858, but forward-ported to 0.11.