### PR TITLE
Fix doc of Options::ENABLE_MATH

### DIFF
--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -467,8 +467,8 @@ bitflags::bitflags! {
         /// literal text [^4]. In old syntax, it creates a dangling link.
         /// ```
         const ENABLE_OLD_FOOTNOTES = (1 << 9) | (1 << 2);
-        /// With this feature enabled, `Tag::Math` events are emitted that
-        /// conventionally contain TeX formulas.
+        /// With this feature enabled, two events `Event::InlineMath` and `Event::DisplayMath`
+        /// are emitted that conventionally contain TeX formulas.
         const ENABLE_MATH = 1 << 10;
     }
 }


### PR DESCRIPTION
There is no `Tag::Math` but two events. This commit fixes this typo.