### PR TITLE
fix: fix dead code warning from nightly compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "bincode",
  "bitflags",

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -1486,10 +1486,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         }
         self.allocs.footdefs.0.insert(
             UniCase::new(label.clone()),
-            FootnoteDef {
-                span: start..i,
-                use_count: 0,
-            },
+            FootnoteDef { use_count: 0 },
         );
         self.tree.append(Item {
             start,

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -1436,7 +1436,6 @@ pub struct LinkDef<'a> {
 /// Contains the destination URL, title and source span of a reference definition.
 #[derive(Clone, Debug)]
 pub struct FootnoteDef {
-    pub span: Range<usize>,
     pub use_count: usize,
 }
 


### PR DESCRIPTION
I got the following warning from nightly rustc.

```
warning: field `span` is never read
    --> pulldown-cmark/src/parse.rs:1439:9
     |
1438 | pub struct FootnoteDef {
     |            ----------- field in this struct
1439 |     pub span: Range<usize>,
     |         ^^^^
     |
     = note: `FootnoteDef` has derived impls for the traits `Debug` and `Clone`, but these are intentionally ignored during dead code analysis
     = note: `#[warn(dead_code)]` on by default

warning: `pulldown-cmark` (lib) generated 1 warning
```

The field is not a public API and it is actually unused. This PR fixes the warning by removing the field.