### PR TITLE
(Re)introduce simd feature to pulldown-cmark-escape

### DIFF
--- a/pulldown-cmark-escape/Cargo.toml
+++ b/pulldown-cmark-escape/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["text-processing"]
 edition = "2021"
 rust-version = "1.70" # Update README.md and azure-pipelines.yml if this changes.
 readme = "../README.md"
+
+[features]
+simd = []

--- a/pulldown-cmark/Cargo.toml
+++ b/pulldown-cmark/Cargo.toml
@@ -81,5 +81,5 @@ bincode = "1.3.1"
 [features]
 default = ["getopts", "html"]
 gen-tests = []
-simd = []
+simd = ["pulldown-cmark-escape?/simd"]
 html = ["pulldown-cmark-escape"]


### PR DESCRIPTION
I noticed the simd portion in `pulldown-cmark-escape/src/lib.rs` was dead code, as there was no `simd` feature defined on the new crate. This introduces that feature and automatically enables it through `pulldown-cmark` as well, if requested.

Guess no one noticed a difference in performance? :D