### PR TITLE
fix: remove unnecessary end_newline set

### DIFF
--- a/pulldown-cmark/src/html.rs
+++ b/pulldown-cmark/src/html.rs
@@ -163,7 +163,6 @@ where
                 attrs,
             } => {
                 if self.end_newline {
-                    self.end_newline = false;
                     self.write("<")?;
                 } else {
                     self.write("\n<")?;


### PR DESCRIPTION
`self.write` sets `self.end_newline = false`:
https://github.com/tomcur/pulldown-cmark/blob/de575f0f328eaf574fd747c8510ce98012a05ddd/pulldown-cmark/src/html.rs#L86-L88