### PR TITLE
feat: set `DefaultBrokenLinkCallback` as the default broken link callback of `OffsetIter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "bitflags",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.1"
+version = "0.11.0"
 
 [[package]]
 name = "quote"

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -1975,7 +1975,7 @@ impl<'input> BrokenLinkCallback<'input> for DefaultBrokenLinkCallback {
 /// Constructed from a `Parser` using its
 /// [`into_offset_iter`](struct.Parser.html#method.into_offset_iter) method.
 #[derive(Debug)]
-pub struct OffsetIter<'a, F> {
+pub struct OffsetIter<'a, F = DefaultBrokenLinkCallback> {
     inner: Parser<'a, F>,
 }
 


### PR DESCRIPTION
`Parser`'s `F` type parameter has the default type `DefaultBrokenLinkCallback` so that users can use the type without caring about the type parameter. However `OffsetIter` doesn't have the default type so users need to specify `DefaultBrokenLinkCallback` manually knowing the API.

This PR sets `DefaultBrokenLinkCallback` to the default callback type of `OffsetIter` as well as `Parser`.