### PR TITLE
fix(test): fix generating spec tests doesn't work on Windows due to line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 /pulldown-cmark/third_party/** eol=lf
 /pulldown-cmark/specs/** eol=lf
-/pulldown-cmark/tests/suite/*.rs eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/pulldown-cmark/third_party/** eol=lf
+/pulldown-cmark/specs/** eol=lf
+/pulldown-cmark/tests/suite/*.rs eol=lf


### PR DESCRIPTION
Fixes #902

`build.rs` assumes the spec text files use LF for line-endings. However it is depending on Git configuration and Git tries to convert them to CRLF on Windows by default. Thus generating spec tests don't work due to the line-endings on Windows.

This PR fixes the issue by explicitly specifying the spec texts should use LF for line-endings in `.gitattributes`.

```
warning: pulldown-cmark@0.11.0: Generated 17 tests in "./tests/suite/blockquotes_tags.rs"
warning: pulldown-cmark@0.11.0: Generated 24 tests in "./tests/suite/footnotes.rs"
warning: pulldown-cmark@0.11.0: Generated 3 tests in "./tests/suite/gfm_strikethrough.rs"
warning: pulldown-cmark@0.11.0: Generated 9 tests in "./tests/suite/gfm_table.rs"
warning: pulldown-cmark@0.11.0: Generated 2 tests in "./tests/suite/gfm_tasklist.rs"
warning: pulldown-cmark@0.11.0: Generated 42 tests in "./tests/suite/heading_attrs.rs"
warning: pulldown-cmark@0.11.0: Generated 47 tests in "./tests/suite/math.rs"
warning: pulldown-cmark@0.11.0: Generated 12 tests in "./tests/suite/metadata_blocks.rs"
warning: pulldown-cmark@0.11.0: Generated 9 tests in "./tests/suite/old_footnotes.rs"
warning: pulldown-cmark@0.11.0: Generated 194 tests in "./tests/suite/regression.rs"
warning: pulldown-cmark@0.11.0: Generated 16 tests in "./tests/suite/smart_punct.rs"
warning: pulldown-cmark@0.11.0: Generated 652 tests in "./tests/suite/spec.rs"
warning: pulldown-cmark@0.11.0: Generated 16 tests in "./tests/suite/strikethrough.rs"
warning: pulldown-cmark@0.11.0: Generated 28 tests in "./tests/suite/table.rs"
```