### PR TITLE
chore(doc): use `cargo add` to instruct how to install this crate as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ By default, the binary is built as well. If you don't want/need it, then build l
 > cargo build --no-default-features
 ```
 
-Or put in your `Cargo.toml` file:
+Or add this package as dependency of your project using `cargo add`:
 
-```toml
-pulldown-cmark = { version = "0.10.3", default-features = false }
+```bash
+> cargo add pulldown-cmark --no-default-features
 ```
 
 SIMD accelerated scanners are available for the x64 platform from version 0.5 onwards. To
@@ -170,10 +170,10 @@ enable them, build with simd feature:
 > cargo build --release --features simd
 ```
 
-Or add the feature to your project's `Cargo.toml`:
+Or add this package as dependency of your project with the feature using `cargo add`:
 
-```toml
-pulldown-cmark = { version = "0.10.3", default-features = false, features = ["simd"] }
+```bash
+> cargo add pulldown-cmark --no-default-features --features=simd
 ```
 
 For a higher release performance you may want this configuration in your profile release:


### PR DESCRIPTION
`cargo add` was introduced recently to Cargo and it works well to install the latest version of this crate as dependency.

Since the version is included in the TOML snippets in README.md, they need to be updated when the major version of this crate is bumped. By using `cargo add`, we no longer need to take care about it and users can easily install this crate as dependency by copy&paste the command line.