### PR TITLE
Fix parsing blocks inside alert body

### DIFF
--- a/pulldown-cmark/specs/blockquotes_tags.txt
+++ b/pulldown-cmark/specs/blockquotes_tags.txt
@@ -191,3 +191,14 @@ Like lazy continuations, the blockquote marker is still needed to make nested bl
 <ul><li>sink ships</li></ul></blockquote>
 </li></ul>
 ````````````````````````````````
+
+When an unknown tag is found, parser backtracks and the block is parsed as a normal blockquote:
+```````````````````````````````` example
+> [!Hello]
+> This should be a normal block quote.
+.
+<blockquote>
+<p>[!Hello]
+This should be a normal block quote.</p>
+</blockquote>
+````````````````````````````````

--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2570,3 +2570,16 @@ _**
 ^_</li>
 </ul>
 ````````````````````````````````
+
+ISSUE #907
+
+```````````````````````````````` example
+> [!Note]
+> - Foo
+.
+<blockquote class="markdown-alert-note">
+<ul>
+<li>Foo</li>
+</ul>
+</blockquote>
+````````````````````````````````

--- a/pulldown-cmark/src/scanners.rs
+++ b/pulldown-cmark/src/scanners.rs
@@ -243,9 +243,6 @@ impl<'a> LineStart<'a> {
             if tag.is_some() && self.scan_ch(b']') {
                 if let Some(nl) = scan_blank_line(&self.bytes[self.ix..]) {
                     self.ix += nl;
-                    while self.scan_ch(b'>') {
-                        self.scan_space(1);
-                    }
                     tag
                 } else {
                     None

--- a/pulldown-cmark/tests/suite/blockquotes_tags.rs
+++ b/pulldown-cmark/tests/suite/blockquotes_tags.rs
@@ -239,3 +239,17 @@ fn blockquotes_tags_test_17() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn blockquotes_tags_test_18() {
+    let original = r##"> [!Hello]
+> This should be a normal block quote.
+"##;
+    let expected = r##"<blockquote>
+<p>[!Hello]
+This should be a normal block quote.</p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3071,3 +3071,18 @@ _**
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_195() {
+    let original = r##"> [!Note]
+> - Foo
+"##;
+    let expected = r##"<blockquote class="markdown-alert-note">
+<ul>
+<li>Foo</li>
+</ul>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
Fixes #907

The root cause is that the parser eats `> ` at the next line after eating the `> [!Note]` line. So the content is parsed as if it is outside the body:

```markdown
> [!Note]
> - Foo
```

is parsed as

```markdown
> [!Note]
- Foo
```

The `> ` at the next line should not be eaten to know the block quote continues.