### PR TITLE
fuzz: fix building fuzzer and improve fuzzing coverage by enabling more parse options

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bitflags",
  "getopts",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "pulldown-cmark-fuzz"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "pulldown-cmark-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -13,6 +13,9 @@ struct FuzzingInput<'a> {
     tasklists: bool,
     smart_punctuation: bool,
     heading_attributes: bool,
+    metadata_block: bool,
+    math: bool,
+    gfm: bool,
 }
 
 fuzz_target!(|data: FuzzingInput<'_>| {
@@ -42,5 +45,17 @@ fuzz_target!(|data: FuzzingInput<'_>| {
         opts.insert(Options::ENABLE_HEADING_ATTRIBUTES);
     }
 
-    for _ in pulldown_cmark::Parser::new_ext(data.markdown, opts) {};
+    if data.metadata_block {
+        opts.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+    }
+
+    if data.math {
+        opts.insert(Options::ENABLE_MATH);
+    }
+
+    if data.gfm {
+        opts.insert(Options::ENABLE_GFM);
+    }
+
+    for _ in pulldown_cmark::Parser::new_ext(data.markdown, opts) {}
 });

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -205,7 +205,7 @@ pub fn xml_to_events(xml: &str) -> anyhow::Result<Vec<Event>> {
                 }
                 b"block_quote" => {
                     block_container_stack.push((true, false));
-                    events.push(Event::Start(Tag::BlockQuote))
+                    events.push(Event::Start(Tag::BlockQuote(None)))
                 },
                 b"html_block" => {
                     events.push(Event::Start(Tag::HtmlBlock));


### PR DESCRIPTION
This PR contains the following chagnes:

- Fix fuzzer cannot be built due to the change to `Tag::BlockQuote` API
- Enable more parse options on fuzzing the parser
  - This improved the code coverage while fuzzing from 4627 lines to 5254 lines (`-runs=1000000`)
- Update the fuzzer crate's edition to Rust 2021. I don't know the reason, but this change slightly improved the code coverage