### PR TITLE
fix: fix warnings reported from nightly rustc

### DIFF
--- a/pulldown-cmark/Cargo.toml
+++ b/pulldown-cmark/Cargo.toml
@@ -83,3 +83,6 @@ default = ["getopts", "html"]
 gen-tests = []
 simd = ["pulldown-cmark-escape?/simd"]
 html = ["pulldown-cmark-escape"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rustbuild)'] }


### PR DESCRIPTION
While working on #910, I noticed the nightly compiler reported warnings like below:

```
warning: unexpected `cfg` condition name: `rustbuild`
  --> /Users/rhysd/Develop/github.com/pulldown-cmark/pulldown-cmark/pulldown-cmark/src/lib.rs:75:13
   |
75 | #![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
   |             ^^^^^^^^^
   |
   = help: consider using a Cargo feature instead
   = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
            [lints.rust]
            unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rustbuild)'] }
   = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(rustbuild)");` to the top of the `build.rs`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

These were reported because rustc recently enabled `unexpected_cfg` lint by default: https://github.com/rust-lang/rust/issues/82450

However the `rustbuild` is a special cfg and I believe the warnings are actually false-positives. This PR suppresses them.