### PR TITLE
Raise the link cutoff from 5 to 32

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2594,3 +2594,17 @@ ISSUE #912
 <hr />
 <h2>--</h2>
 ````````````````````````````````
+
+ISSUE #917
+
+Technically, commonmark only requires our nesting cutoff to stop at 3.
+However, real user reports show that this limit is low enough to hit in reasonable circumstances.
+We instead set the limit at 32, which is the same limit used by cmark-gfm and markdown-it (making it a de facto standard).
+
+```````````````````````````````` example_metadata_blocks
+[30](https://rust.org/something%3A((((((((((((((((((((((((((((((())))))))))))))))))))))))))))))))
+[40](https://rust.org/something%3A((((((((((((((((((((((((((((((((((((((((())))))))))))))))))))))))))))))))))))))))))
+.
+<p><a href="https://rust.org/something%3A((((((((((((((((((((((((((((((()))))))))))))))))))))))))))))))">30</a>
+[40](https://rust.org/something%3A((((((((((((((((((((((((((((((((((((((((())))))))))))))))))))))))))))))))))))))))))</p>
+````````````````````````````````

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -43,7 +43,7 @@ use crate::{
 // The simplest countermeasure is to limit their depth, which is
 // explicitly allowed by the spec as long as the limit is at least 3:
 // https://spec.commonmark.org/0.29/#link-destination
-pub(crate) const LINK_MAX_NESTED_PARENS: usize = 5;
+pub(crate) const LINK_MAX_NESTED_PARENS: usize = 32;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct Item {

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3099,3 +3099,15 @@ fn regression_test_196() {
 
     test_markdown_html(original, expected, false, true, false);
 }
+
+#[test]
+fn regression_test_197() {
+    let original = r##"[30](https://rust.org/something%3A((((((((((((((((((((((((((((((())))))))))))))))))))))))))))))))
+[40](https://rust.org/something%3A((((((((((((((((((((((((((((((((((((((((())))))))))))))))))))))))))))))))))))))))))
+"##;
+    let expected = r##"<p><a href="https://rust.org/something%3A((((((((((((((((((((((((((((((()))))))))))))))))))))))))))))))">30</a>
+[40](https://rust.org/something%3A((((((((((((((((((((((((((((((((((((((((())))))))))))))))))))))))))))))))))))))))))</p>
+"##;
+
+    test_markdown_html(original, expected, false, true, false);
+}


### PR DESCRIPTION
This makes the cutoff for pulldown-cmark the same as the reference implementation and markdown-it. According to criterion, the change is within the noise threshold for the `pathological_link_def` test case.

Fixes #896 

> ## Change Since Previous Benchmark
>
> ![image](https://github.com/pulldown-cmark/pulldown-cmark/assets/1593513/44a40942-f048-4e24-80de-b56f2f4c72f6)
>
> ![image](https://github.com/pulldown-cmark/pulldown-cmark/assets/1593513/058e3490-84b8-45a1-938a-da210f9ee6ff)
>
> <h4>Additional Statistics:</h4>
>
>  | Lower bound | Estimate | Upper bound |  
> -- | -- | -- | -- | --
> Change in time | -1.0293% | -0.7940% | -0.5671% | (p = 0.00 < 0.05)
> Change in throughput | +1.0400% | +0.8004% | +0.5704% |  
>
> Change within noise threshold.
            