### PR TITLE
ci: fix deploying the document to GitHub Pages and make the deploy job faster

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -17,7 +17,11 @@ jobs:
     - name: Install Rust
       run: rustup default stable
     - name: Install mdBook
-      run: cargo install mdbook@0.4.40
+      run: |
+        mkdir mdbook && cd mdbook
+        curl -LO 'https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz'
+        tar xf mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz
+        echo "$(pwd)" >> $GITHUB_PATH
     - name: Prepare book
       working-directory: guide
       run: |

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Rust
       run: rustup default stable
     - name: Install mdBook
-      run: cargo install mdbook@0.4.37
+      run: cargo install mdbook@0.4.40
     - name: Prepare book
       working-directory: guide
       run: |
@@ -25,7 +25,7 @@ jobs:
         ./prepare-specs
         mdbook build
     - name: Upload Artifact
-      uses: actions/upload-pages-artifact@v1.0.8
+      uses: actions/upload-pages-artifact@v3.0.1
       with:
         path: ./guide/book
 
@@ -45,4 +45,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v2.0.0
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
This PR fixes deploying GitHub Pages site (added at #883).

I confirmed the build and deploy were done successfully:

- Job run: https://github.com/rhysd/pulldown-cmark/actions/runs/9795009035/job/27046194652
- Deployed website: https://rhysd.github.io/pulldown-cmark/