### PR TITLE
Add reproduction cases for #927

### DIFF
--- a/pulldown-cmark/specs/footnotes.txt
+++ b/pulldown-cmark/specs/footnotes.txt
@@ -646,3 +646,37 @@ footnote [^quux]</p>
 <p>x</p>
 </div>
 ````````````````````````````````
+
+Multiple footnotes should be able without needing whitespace in between.
+
+```````````````````````````````` example
+Lorem ipsum.[^a][^b]
+
+[^a]: Foo
+[^b]: Bar
+.
+<p>Lorem ipsum.<sup class="footnote-reference"><a href="#a">1</a></sup><sup class="footnote-reference"><a href="#b">2</a></sup></p>
+<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
+<p>Foo</p>
+</div>
+<div class="footnote-definition" id="b"><sup class="footnote-definition-label">2</sup>
+<p>Bar</p>
+</div>
+````````````````````````````````
+
+This does work already:
+
+```````````````````````````````` example
+Lorem ipsum.[^a] [^b]
+
+[^a]: Foo
+[^b]: Bar
+.
+<p>Lorem ipsum.<sup class="footnote-reference"><a href="#a">1</a></sup> <sup class="footnote-reference"><a href="#b">2</a></sup></p>
+<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
+<p>Foo</p>
+</div>
+<div class="footnote-definition" id="b"><sup class="footnote-definition-label">2</sup>
+<p>Bar</p>
+</div>
+````````````````````````````````

--- a/pulldown-cmark/specs/old_footnotes.txt
+++ b/pulldown-cmark/specs/old_footnotes.txt
@@ -161,3 +161,37 @@ Second check for footnotes:
 .
 <p>[Reference to footnotes A<sup class="footnote-reference"><a href="#1">1</a></sup>, B<sup class="footnote-reference"><a href="#2">2</a></sup> and C<sup class="footnote-reference"><a href="#3">3</a></sup>.</p><div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup><p>Footnote A.</p></div><div class="footnote-definition" id="2"><sup class="footnote-definition-label">2</sup><p>Footnote B.</p></div><div class="footnote-definition" id="3"><sup class="footnote-definition-label">3</sup><p>Footnote C.</p></div>
 ````````````````````````````````
+
+Multiple footnotes should be able without needing whitespace in between.
+
+```````````````````````````````` example
+Lorem ipsum.[^a][^b]
+
+[^a]: Foo
+[^b]: Bar
+.
+<p>Lorem ipsum.<sup class="footnote-reference"><a href="#a">1</a></sup><sup class="footnote-reference"><a href="#b">2</a></sup></p>
+<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
+<p>Foo</p>
+</div>
+<div class="footnote-definition" id="b"><sup class="footnote-definition-label">2</sup>
+<p>Bar</p>
+</div>
+````````````````````````````````
+
+This does work already:
+
+```````````````````````````````` example
+Lorem ipsum.[^a] [^b]
+
+[^a]: Foo
+[^b]: Bar
+.
+<p>Lorem ipsum.<sup class="footnote-reference"><a href="#a">1</a></sup> <sup class="footnote-reference"><a href="#b">2</a></sup></p>
+<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
+<p>Foo</p>
+</div>
+<div class="footnote-definition" id="b"><sup class="footnote-definition-label">2</sup>
+<p>Bar</p>
+</div>
+````````````````````````````````

--- a/pulldown-cmark/tests/suite/footnotes.rs
+++ b/pulldown-cmark/tests/suite/footnotes.rs
@@ -646,3 +646,41 @@ footnote [^quux]</p>
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn footnotes_test_25() {
+    let original = r##"Lorem ipsum.[^a][^b]
+
+[^a]: Foo
+[^b]: Bar
+"##;
+    let expected = r##"<p>Lorem ipsum.<sup class="footnote-reference"><a href="#a">1</a></sup><sup class="footnote-reference"><a href="#b">2</a></sup></p>
+<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
+<p>Foo</p>
+</div>
+<div class="footnote-definition" id="b"><sup class="footnote-definition-label">2</sup>
+<p>Bar</p>
+</div>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn footnotes_test_26() {
+    let original = r##"Lorem ipsum.[^a] [^b]
+
+[^a]: Foo
+[^b]: Bar
+"##;
+    let expected = r##"<p>Lorem ipsum.<sup class="footnote-reference"><a href="#a">1</a></sup> <sup class="footnote-reference"><a href="#b">2</a></sup></p>
+<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
+<p>Foo</p>
+</div>
+<div class="footnote-definition" id="b"><sup class="footnote-definition-label">2</sup>
+<p>Bar</p>
+</div>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}

--- a/pulldown-cmark/tests/suite/old_footnotes.rs
+++ b/pulldown-cmark/tests/suite/old_footnotes.rs
@@ -175,3 +175,41 @@ fn old_footnotes_test_9() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn old_footnotes_test_10() {
+    let original = r##"Lorem ipsum.[^a][^b]
+
+[^a]: Foo
+[^b]: Bar
+"##;
+    let expected = r##"<p>Lorem ipsum.<sup class="footnote-reference"><a href="#a">1</a></sup><sup class="footnote-reference"><a href="#b">2</a></sup></p>
+<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
+<p>Foo</p>
+</div>
+<div class="footnote-definition" id="b"><sup class="footnote-definition-label">2</sup>
+<p>Bar</p>
+</div>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn old_footnotes_test_11() {
+    let original = r##"Lorem ipsum.[^a] [^b]
+
+[^a]: Foo
+[^b]: Bar
+"##;
+    let expected = r##"<p>Lorem ipsum.<sup class="footnote-reference"><a href="#a">1</a></sup> <sup class="footnote-reference"><a href="#b">2</a></sup></p>
+<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
+<p>Foo</p>
+</div>
+<div class="footnote-definition" id="b"><sup class="footnote-definition-label">2</sup>
+<p>Bar</p>
+</div>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
#928 is meant to fix #927, but [it doesn't address the actual issue](https://github.com/pulldown-cmark/pulldown-cmark/pull/928#issuecomment-2284807396) I described. After figuring out how test cases are generated, I prepared this to demonstrate the issue better.

(You will not want to merge this as is, it has failing tests)