### PR TITLE
Add support for generating html for markdown which should be shown inline

### DIFF
--- a/pulldown-cmark/examples/broken-link-callbacks.rs
+++ b/pulldown-cmark/examples/broken-link-callbacks.rs
@@ -23,7 +23,7 @@ fn main() {
 
     // Write to String buffer.
     let mut html_output: String = String::with_capacity(input.len() * 3 / 2);
-    html::push_html(&mut html_output, parser);
+    html::push_html(&mut html_output, parser, false);
 
     // Check that the output is what we expected.
     let expected_html: &str =

--- a/pulldown-cmark/examples/event-filter.rs
+++ b/pulldown-cmark/examples/event-filter.rs
@@ -23,5 +23,5 @@ fn main() {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     handle.write_all(b"\nHTML output:\n").unwrap();
-    html::write_html_io(&mut handle, parser).unwrap();
+    html::write_html_io(&mut handle, parser, false).unwrap();
 }

--- a/pulldown-cmark/examples/footnote-rewrite.rs
+++ b/pulldown-cmark/examples/footnote-rewrite.rs
@@ -53,7 +53,7 @@ fn main() {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     handle.write_all(b"\nHTML output:\n").unwrap();
-    html::write_html_io(&mut handle, parser).unwrap();
+    html::write_html_io(&mut handle, parser, false).unwrap();
 
     // To make the footnotes look right, we need to sort them by their appearance order, not by
     // the in-tree order of their actual definitions. Unused items are omitted entirely.
@@ -160,6 +160,7 @@ fn main() {
                     f => f,
                 })
             }),
+            false
         )
         .unwrap();
         handle.write_all(b"</ol>\n").unwrap();

--- a/pulldown-cmark/examples/parser-map-event-print.rs
+++ b/pulldown-cmark/examples/parser-map-event-print.rs
@@ -31,6 +31,6 @@ fn main() {
     });
 
     let mut html_output = String::new();
-    html::push_html(&mut html_output, parser);
+    html::push_html(&mut html_output, parser, false);
     println!("\nHTML output:\n{}\n", &html_output);
 }

--- a/pulldown-cmark/examples/parser-map-tag-print.rs
+++ b/pulldown-cmark/examples/parser-map-tag-print.rs
@@ -102,6 +102,6 @@ fn main() {
     });
 
     let mut html_output = String::new();
-    pulldown_cmark::html::push_html(&mut html_output, parser);
+    pulldown_cmark::html::push_html(&mut html_output, parser, false);
     println!("\nHTML output:\n{}\n", &html_output);
 }

--- a/pulldown-cmark/examples/string-to-string.rs
+++ b/pulldown-cmark/examples/string-to-string.rs
@@ -12,7 +12,7 @@ fn main() {
 
     // Write to String buffer.
     let mut html_output: String = String::with_capacity(markdown_input.len() * 3 / 2);
-    html::push_html(&mut html_output, parser);
+    html::push_html(&mut html_output, parser, false);
 
     // Check that the output is what we expected.
     let expected_html: &str =

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -41,7 +41,7 @@
 //! # #[cfg(feature = "html")] {
 //! // Write to String buffer.
 //! let mut html_output = String::new();
-//! pulldown_cmark::html::push_html(&mut html_output, parser);
+//! pulldown_cmark::html::push_html(&mut html_output, parser, false);
 //!
 //! // Check that the output is what we expected.
 //! let expected_html = "<p>Hello world, this is a <del>complicated</del> <em>very simple</em> example.</p>\n";

--- a/pulldown-cmark/src/main.rs
+++ b/pulldown-cmark/src/main.rs
@@ -191,5 +191,5 @@ pub fn pulldown_cmark(input: &str, opts: Options, broken_links: &mut Vec<BrokenL
     );
     let stdio = io::stdout();
     let buffer = std::io::BufWriter::with_capacity(1024 * 1024, stdio.lock());
-    let _ = html::write_html_io(buffer, &mut p);
+    let _ = html::write_html_io(buffer, &mut p, false);
 }

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -2402,7 +2402,7 @@ mod test {
         let expected = "<p><a href=\"https://vincentprouillet.com\">My site</a></p>\n";
 
         let mut buf = String::new();
-        crate::html::push_html(&mut buf, Parser::new(test_str));
+        crate::html::push_html(&mut buf, Parser::new(test_str), false);
         assert_eq!(expected, buf);
     }
 
@@ -2413,7 +2413,7 @@ mod test {
         let expected = "<p>a <a href=\"yolo\">^a</a></p>\n";
 
         let mut buf = String::new();
-        crate::html::push_html(&mut buf, Parser::new(test_str));
+        crate::html::push_html(&mut buf, Parser::new(test_str), false);
         assert_eq!(expected, buf);
     }
 
@@ -2424,7 +2424,7 @@ mod test {
         let expected = "";
 
         let mut buf = String::new();
-        crate::html::push_html(&mut buf, Parser::new(test_str));
+        crate::html::push_html(&mut buf, Parser::new(test_str), false);
         assert_eq!(expected, buf);
     }
 
@@ -2435,7 +2435,7 @@ mod test {
         let expected = "<p><a href=\"/u\">a</a></p>\n";
 
         let mut buf = String::new();
-        crate::html::push_html(&mut buf, Parser::new(test_str));
+        crate::html::push_html(&mut buf, Parser::new(test_str), false);
         assert_eq!(expected, buf);
     }
 
@@ -2446,7 +2446,7 @@ mod test {
         let expected = "<p>[a]:</p>\n";
 
         let mut buf = String::new();
-        crate::html::push_html(&mut buf, Parser::new(test_str));
+        crate::html::push_html(&mut buf, Parser::new(test_str), false);
         assert_eq!(expected, buf);
     }
 

--- a/pulldown-cmark/tests/html.rs
+++ b/pulldown-cmark/tests/html.rs
@@ -30,7 +30,7 @@ console.log("fooooo");
 </script>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -63,7 +63,7 @@ console.log("fooooo");
 </script>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -82,7 +82,7 @@ fn html_test_3() {
 ?>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -101,7 +101,7 @@ fn html_test_4() {
 -->"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -120,7 +120,7 @@ fn html_test_5() {
 ]]>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -137,7 +137,7 @@ Some things are here...
 >"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -169,7 +169,7 @@ console.log("fooooo");
 </script>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -184,7 +184,7 @@ fn html_test_8() {
     let mut s = String::new();
     let mut opts = Options::empty();
     opts.insert(Options::ENABLE_TABLES);
-    html::push_html(&mut s, Parser::new_ext(original, opts));
+    html::push_html(&mut s, Parser::new_ext(original, opts), false);
     assert_eq!(expected, s);
 }
 
@@ -194,7 +194,7 @@ fn html_test_9() {
     let expected = "<hr />\n";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -204,7 +204,7 @@ fn html_test_10() {
     let expected = "<hr />\n";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
     assert_eq!(expected, s);
 }
 
@@ -214,7 +214,17 @@ fn html_test_11() {
     let expected = "<p>hi ~~no~~</p>\n";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn html_test_11_inline() {
+    let original = "hi ~~no~~";
+    let expected = "<span>hi ~~no~~</span>\n";
+
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(original), true);
     assert_eq!(expected, s);
 }
 
@@ -245,7 +255,7 @@ fn html_test_broken_callback() {
     };
 
     let p = Parser::new_with_broken_link_callback(original, Options::empty(), Some(&mut callback));
-    html::push_html(&mut s, p);
+    html::push_html(&mut s, p, false);
 
     assert_eq!(expected, s);
 }
@@ -257,7 +267,19 @@ fn newline_in_code() {
 
     for original in originals {
         let mut s = String::new();
-        html::push_html(&mut s, Parser::new(original));
+        html::push_html(&mut s, Parser::new(original), false);
+        assert_eq!(expected, s);
+    }
+}
+
+#[test]
+fn newline_in_code_inline() {
+    let originals = ["`\n `x", "` \n`x"];
+    let expected = "<span><code>  </code>x</span>\n";
+
+    for original in originals {
+        let mut s = String::new();
+        html::push_html(&mut s, Parser::new(original), true);
         assert_eq!(expected, s);
     }
 }
@@ -268,7 +290,17 @@ fn newline_start_end_of_code() {
     let expected = "<p><code>x</code>x</p>\n";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn newline_start_end_of_code_inline() {
+    let original = "`\nx\n`x";
+    let expected = "<span><code>x</code>x</span>\n";
+
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(original), true);
     assert_eq!(expected, s);
 }
 
@@ -280,7 +312,18 @@ fn trim_space_and_tab_at_end_of_paragraph() {
     let expected = "<p>one\ntwo</p>\n";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
+    assert_eq!(expected, s);
+}
+
+
+#[test]
+fn trim_space_and_tab_at_end_of_paragraph_inline() {
+    let original = "one\ntwo \t";
+    let expected = "<span>one\ntwo</span>\n";
+
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(original), true);
     assert_eq!(expected, s);
 }
 
@@ -291,7 +334,20 @@ fn newline_within_code() {
 
     for original in originals {
         let mut s = String::new();
-        html::push_html(&mut s, Parser::new(original));
+        html::push_html(&mut s, Parser::new(original), false);
+        assert_eq!(expected, s);
+    }
+}
+
+
+#[test]
+fn newline_within_code_inline() {
+    let originals = ["`\nx \ny\n`x", "`x \ny`x", "`x\n y`x"];
+    let expected = "<span><code>x  y</code>x</span>\n";
+
+    for original in originals {
+        let mut s = String::new();
+        html::push_html(&mut s, Parser::new(original), true);
         assert_eq!(expected, s);
     }
 }
@@ -302,7 +358,17 @@ fn trim_space_tab_nl_at_end_of_paragraph() {
     let expected = "<p>one\ntwo</p>\n";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn trim_space_tab_nl_at_end_of_paragraph_inline() {
+    let original = "one\ntwo \t\n";
+    let expected = "<span>one\ntwo</span>\n";
+
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(original), true);
     assert_eq!(expected, s);
 }
 
@@ -312,7 +378,17 @@ fn trim_space_nl_at_end_of_paragraph() {
     let expected = "<p>one\ntwo</p>\n";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn trim_space_nl_at_end_of_paragraph_inline() {
+    let original = "one\ntwo \n";
+    let expected = "<span>one\ntwo</span>\n";
+
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(original), true);
     assert_eq!(expected, s);
 }
 
@@ -322,7 +398,17 @@ fn trim_space_before_soft_break() {
     let expected = "<p>one\ntwo</p>\n";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    html::push_html(&mut s, Parser::new(original), false);
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn trim_space_before_soft_break_inline() {
+    let original = "one \ntwo";
+    let expected = "<span>one\ntwo</span>\n";
+
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(original), true);
     assert_eq!(expected, s);
 }
 
@@ -336,7 +422,7 @@ fn issue_819() {
 
     for orig in original {
         let mut s = String::new();
-        html::push_html(&mut s, Parser::new(orig));
+        html::push_html(&mut s, Parser::new(orig), false);
         // Trailing newline doesn't matter. Just the actual HTML.
         assert_eq!(expected, s.trim_end_matches('\n'));
     }
@@ -344,7 +430,7 @@ fn issue_819() {
         let mut s = String::new();
         let mut opts = Options::empty();
         opts.insert(Options::ENABLE_HEADING_ATTRIBUTES);
-        html::push_html(&mut s, Parser::new_ext(orig, opts));
+        html::push_html(&mut s, Parser::new_ext(orig, opts), false);
         // Trailing newline doesn't matter. Just the actual HTML.
         assert_eq!(expected, s.trim_end_matches('\n'));
     }

--- a/pulldown-cmark/tests/lib.rs
+++ b/pulldown-cmark/tests/lib.rs
@@ -35,7 +35,7 @@ pub fn test_markdown_html(
     opts.insert(Options::ENABLE_HEADING_ATTRIBUTES);
 
     let p = Parser::new_ext(input, opts);
-    pulldown_cmark::html::push_html(&mut s, p);
+    pulldown_cmark::html::push_html(&mut s, p, false);
 
     // normalizing the HTML using html5ever may hide actual errors
     // assert_eq!(html_standardize(output), html_standardize(&s));


### PR DESCRIPTION
I don't know if this is something you want in this crate, but I needed it so I implemented it :) 

Basically this PR adds an `inline: bool` argument for html generation which let's the generator add `span`-tags instead of `p`-tags around a markdown paragraph.

The current implementation is somewhat of a 'breaking' change as the functions to generate html now have an extra argument. An alternative could be to duplicate the methods for inline generation instead of adding an argument.

