### PR TITLE
Renovate the superlinear time fuzzer

### DIFF
--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -4,78 +4,70 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "autocfg"
-version = "0.1.8"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "bitflags"
-version = "2.4.2"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -85,9 +77,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -95,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -107,54 +99,39 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
-]
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "fuzzer"
@@ -162,17 +139,17 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "crossbeam-utils",
- "itertools 0.8.2",
+ "itertools",
  "libc",
  "ndarray",
  "ndarray-stats",
  "num_cpus",
  "pulldown-cmark",
- "rand 0.7.3",
+ "rand",
  "rand_xoshiro",
  "serde",
  "serde_json",
- "syn 0.15.44",
+ "syn",
  "walkdir",
 ]
 
@@ -187,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -204,15 +181,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "indexmap"
@@ -220,118 +197,115 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.7.11"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
-dependencies = [
- "either",
-]
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.1.15"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcad67dcec2d58ff56f6292582377e6921afdf3bfbd533e26fb8900ae575e002"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "ndarray"
-version = "0.12.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf380a8af901ad627594013a3bbac903ae0a6f94e176e47e46b5bbc1877b928"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
 dependencies = [
- "itertools 0.7.11",
  "matrixmultiply",
  "num-complex",
+ "num-integer",
  "num-traits",
+ "rawpointer",
 ]
 
 [[package]]
 name = "ndarray-stats"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4570b4f029fb2a8bd5f1f629753fb0b01c0cc8343f5eb77c9dc6699d9cf7b036"
+checksum = "af5a8477ac96877b5bd1fd67e0c28736c12943aba24eda92b127e036b0c8f400"
 dependencies = [
  "indexmap",
- "itertools 0.8.2",
+ "itertools",
  "ndarray",
  "noisy_float",
  "num-integer",
  "num-traits",
- "rand 0.6.5",
+ "rand",
 ]
 
 [[package]]
 name = "noisy_float"
-version = "0.1.15"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deb89f8062c0dce4c805a987daff07f92e17c560f7c3ed631282555af902258"
+checksum = "978fe6e6ebc0bf53de533cd456ca2d9de13de13856eda1518a285d7705a213af"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "autocfg 1.1.0",
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg 1.1.0",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -346,33 +320,27 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "unicode-xid",
+ "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -381,202 +349,67 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
-dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.6.5"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "autocfg 0.1.8",
  "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "rand_core 0.4.2",
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
 name = "rawpointer"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -589,60 +422,50 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -663,33 +486,27 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -697,40 +514,18 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -742,14 +537,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.0"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -758,42 +563,69 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -5,15 +5,15 @@ authors = ["oberien <jaro.fietz@gmx.de>"]
 edition = "2018"
 
 [dependencies]
-syn = { version = "0.15", features = ["full"] }
-itertools = "0.8"
-walkdir = "2.2"
+syn = { version = "2", features = ["full", "visit"] }
+itertools = "0.10"
+walkdir = "2.5"
 pulldown-cmark = { path = "../pulldown-cmark" }
-ndarray = "0.12"
-ndarray-stats = "0.2"
-rand = "0.7"
-rand_xoshiro = "0.4"
-num_cpus = "1.10"
+ndarray = "0.15"
+ndarray-stats = "0.5"
+rand = "0.8"
+rand_xoshiro = "0.6"
+num_cpus = "1.16"
 crossbeam-utils = "0.8"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
@@ -26,4 +26,3 @@ lto = "fat"
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
-

--- a/fuzzer/src/literals.rs
+++ b/fuzzer/src/literals.rs
@@ -17,7 +17,7 @@ use walkdir::WalkDir;
 pub fn get() -> Vec<Vec<u8>> {
     // Get relevant literals from pulldown-cmark's source code.
     // See documentaiton of `literals`-module for more information.
-    let walkdir = WalkDir::new("../src")
+    let walkdir = WalkDir::new("../pulldown-cmark/src")
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())
@@ -31,7 +31,10 @@ pub fn get() -> Vec<Vec<u8>> {
 
     let mut literal_parser = LiteralParser::new();
 
-    let skipped_files = &[Path::new("../src/entities.rs"), Path::new("../src/main.rs")];
+    let skipped_files = &[
+        Path::new("../pulldown-cmark/src/entities.rs"),
+        Path::new("../pulldown-cmark/src/main.rs"),
+    ];
     for file in walkdir {
         if skipped_files.contains(&file.path()) {
             continue;

--- a/fuzzer/src/literals.rs
+++ b/fuzzer/src/literals.rs
@@ -57,7 +57,7 @@ pub fn get() -> Vec<Vec<u8>> {
 
     literals
         .into_iter()
-        .filter(|lit| !lit.contains(&b'\n'))
+        .filter(|lit| !lit.contains(&b'\n') || lit.len() == 1)
         .filter(|lit| !lit.is_empty())
         .collect()
 }

--- a/fuzzer/src/literals.rs
+++ b/fuzzer/src/literals.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
-use syn::{Expr, ExprArray, ExprCall, ExprMethodCall, ExprTuple, ImplItem, Item, Lit, Pat, Stmt};
+use syn::{visit::Visit, Lit};
 use walkdir::WalkDir;
 
 /// Get all relevant literals from pulldown-cmark to generate fuzzing input from.
@@ -87,87 +87,19 @@ impl LiteralParser {
         let path = path.as_ref();
         let content = fs::read_to_string(path).expect(&format!("unable to read file {:?}", path));
         let parsed = syn::parse_file(&content).expect(&format!("unable to parse file {:?}", path));
-        self.extract_literals_from_items(parsed.items);
+        self.visit_file(&parsed);
     }
+}
 
-    fn extract_literals_from_items(&mut self, items: Vec<Item>) {
-        for item in items {
-            self.extract_literals_from_item(item);
-        }
-    }
-
-    fn extract_literals_from_item(&mut self, item: Item) {
-        match item {
-            Item::ExternCrate(_)
-            | Item::Use(_)
-            | Item::ForeignMod(_)
-            | Item::Type(_)
-            | Item::Existential(_)
-            | Item::Struct(_)
-            | Item::Enum(_)
-            | Item::Union(_)
-            | Item::Trait(_)
-            | Item::TraitAlias(_)
-            | Item::Verbatim(_) => (),
-            Item::Static(item) => {
-                self.in_static = true;
-                self.extract_literals_from_expr(*item.expr);
-                self.in_static = false;
-            }
-            Item::Const(item) => {
-                self.in_const = true;
-                self.extract_literals_from_expr(*item.expr);
-                self.in_const = false;
-            }
-            Item::Fn(item) => self.extract_literals_from_stmts(item.block.stmts),
-            Item::Mod(item) => {
-                if let Some((_, item)) = item.content {
-                    self.extract_literals_from_items(item);
-                }
-            }
-            Item::Impl(item) => self.extract_literals_from_impl(item.items),
-            Item::Macro(_) => (),
-            Item::Macro2(_) => unimplemented!("macros 2.0"),
-        }
-    }
-
-    fn extract_literals_from_stmts(&mut self, stmts: Vec<Stmt>) {
-        for stmt in stmts {
-            match stmt {
-                Stmt::Local(local) => {
-                    if let Some((_, expr)) = local.init {
-                        self.extract_literals_from_expr(*expr);
-                    }
-                }
-                Stmt::Item(item) => self.extract_literals_from_item(item),
-                Stmt::Expr(expr) | Stmt::Semi(expr, _) => self.extract_literals_from_expr(expr),
-            }
-        }
-    }
-
-    fn extract_literals_from_impl(&mut self, items: Vec<ImplItem>) {
-        for item in items {
-            match item {
-                ImplItem::Const(item) => {
-                    self.in_const = true;
-                    self.extract_literals_from_expr(item.expr);
-                    self.in_const = false;
-                }
-                ImplItem::Method(item) => self.extract_literals_from_stmts(item.block.stmts),
-                ImplItem::Type(_) | ImplItem::Existential(_) => (),
-                ImplItem::Macro(_) => (),
-                ImplItem::Verbatim(_) => unimplemented!("ImplItem::Verbatim"),
-            }
-        }
-    }
-
-    fn extract_literals_from_lit(&mut self, lit: Lit) {
+impl<'ast> Visit<'ast> for LiteralParser {
+    fn visit_lit(&mut self, lit: &'ast Lit) {
         if self.condition_depth == 0 && !self.in_static && !self.in_const {
             return;
         }
         match lit {
             Lit::Str(s) => drop(self.literals.insert(s.value().into_bytes())),
             Lit::ByteStr(s) => drop(self.literals.insert(s.value())),
+            Lit::CStr(s) => drop(self.literals.insert(s.value().into_bytes())),
             Lit::Byte(b) => drop(self.literals.insert(vec![b.value()])),
             Lit::Char(c) => {
                 let c = c.value();
@@ -175,195 +107,73 @@ impl LiteralParser {
                 c.encode_utf8(&mut v);
                 self.literals.insert(v);
             }
-            Lit::Int(_) | Lit::Float(_) | Lit::Bool(_) | Lit::Verbatim(_) => (),
+            _ => (),
         }
     }
 
-    fn extract_literals_from_expr(&mut self, expr: Expr) {
-        match expr {
-            Expr::Box(expr) => self.extract_literals_from_expr(*expr.expr),
-            Expr::InPlace(expr) => self.extract_literals_from_expr(*expr.value),
-            Expr::Array(ExprArray { elems, .. }) => {
-                // If an array is used, we assume that all elements are equal.
-                // For example in `if ["foo", "bar"].contains(baz) {` it's enough to just extract the
-                // first element to cover that branch.
-                if let Some(elem) = elems.into_iter().next() {
-                    self.extract_literals_from_expr(elem);
-                }
-            }
-            Expr::Tuple(ExprTuple { elems, .. }) => {
-                for expr in elems {
-                    self.extract_literals_from_expr(expr);
-                }
-            }
-            Expr::Call(ExprCall { func, args, .. })
-            | Expr::MethodCall(ExprMethodCall {
-                args,
-                receiver: func,
-                ..
-            }) => {
-                self.extract_literals_from_expr(*func);
-                for arg in args {
-                    self.extract_literals_from_expr(arg);
-                }
-            }
-            Expr::Binary(expr) => {
-                self.extract_literals_from_expr(*expr.left);
-                self.extract_literals_from_expr(*expr.right);
-            }
-            Expr::Unary(expr) => self.extract_literals_from_expr(*expr.expr),
-            Expr::Lit(expr) => self.extract_literals_from_lit(expr.lit),
-            Expr::Cast(_) => (),
-            Expr::Type(expr) => self.extract_literals_from_expr(*expr.expr),
-            Expr::Let(expr) => {
-                self.condition_depth += 1;
-                for pat in expr.pats {
-                    self.extract_literals_from_pat(pat);
-                }
-                self.condition_depth -= 1;
-                self.extract_literals_from_expr(*expr.expr)
-            }
-            Expr::If(expr) => {
-                self.condition_depth += 1;
-                self.extract_literals_from_expr(*expr.cond);
-                self.condition_depth -= 1;
-                self.extract_literals_from_stmts(expr.then_branch.stmts);
-                if let Some((_, expr)) = expr.else_branch {
-                    self.extract_literals_from_expr(*expr)
-                }
-            }
-            Expr::While(expr) => {
-                self.condition_depth += 1;
-                self.extract_literals_from_expr(*expr.cond);
-                self.condition_depth -= 1;
-                self.extract_literals_from_stmts(expr.body.stmts);
-            }
-            Expr::ForLoop(expr) => {
-                self.condition_depth += 1;
-                self.extract_literals_from_expr(*expr.expr);
-                self.condition_depth -= 1;
-                self.extract_literals_from_stmts(expr.body.stmts);
-            }
-            Expr::Loop(expr) => self.extract_literals_from_stmts(expr.body.stmts),
-            Expr::Match(arm) => {
-                self.condition_depth += 1;
-                self.extract_literals_from_expr(*arm.expr);
-                self.condition_depth -= 1;
-                for arm in arm.arms {
-                    self.condition_depth += 1;
-                    for pat in arm.pats {
-                        self.extract_literals_from_pat(pat);
-                    }
-                    if let Some((_, guard)) = arm.guard {
-                        self.extract_literals_from_expr(*guard);
-                    }
-                    self.condition_depth -= 1;
-                    self.extract_literals_from_expr(*arm.body);
-                }
-            }
-            // TODO: are closure argument patterns relevant?
-            Expr::Closure(expr) => self.extract_literals_from_expr(*expr.body),
-            Expr::Unsafe(expr) => self.extract_literals_from_stmts(expr.block.stmts),
-            Expr::Block(expr) => self.extract_literals_from_stmts(expr.block.stmts),
-            Expr::Assign(expr) => {
-                self.extract_literals_from_expr(*expr.left);
-                self.extract_literals_from_expr(*expr.right);
-            }
-            Expr::AssignOp(expr) => {
-                self.extract_literals_from_expr(*expr.left);
-                self.extract_literals_from_expr(*expr.right);
-            }
-            Expr::Field(expr) => self.extract_literals_from_expr(*expr.base),
-            Expr::Index(expr) => {
-                self.extract_literals_from_expr(*expr.expr);
-                self.extract_literals_from_expr(*expr.index);
-            }
-            // from is enough as we can trigger that range with the beginning
-            Expr::Range(expr) => {
-                if let Some(val) = expr.from.or(expr.to) {
-                    self.extract_literals_from_expr(*val);
-                }
-            }
-            Expr::Path(_) => (),
-            Expr::Reference(expr) => self.extract_literals_from_expr(*expr.expr),
-            Expr::Break(expr) => {
-                if let Some(expr) = expr.expr {
-                    self.extract_literals_from_expr(*expr);
-                }
-            }
-            Expr::Continue(_) => (),
-            Expr::Return(expr) => {
-                if let Some(expr) = expr.expr {
-                    self.extract_literals_from_expr(*expr);
-                }
-            }
-            Expr::Macro(_) => (),
-            Expr::Struct(expr) => {
-                for field in expr.fields {
-                    self.extract_literals_from_expr(field.expr);
-                }
-                if let Some(expr) = expr.rest {
-                    self.extract_literals_from_expr(*expr);
-                }
-            }
-            Expr::Repeat(expr) => {
-                self.extract_literals_from_expr(*expr.expr);
-                self.extract_literals_from_expr(*expr.len);
-            }
-            Expr::Paren(expr) => self.extract_literals_from_expr(*expr.expr),
-            Expr::Group(expr) => self.extract_literals_from_expr(*expr.expr),
-            Expr::Try(expr) => self.extract_literals_from_expr(*expr.expr),
-            Expr::Async(expr) => self.extract_literals_from_stmts(expr.block.stmts),
-            Expr::TryBlock(expr) => self.extract_literals_from_stmts(expr.block.stmts),
-            Expr::Yield(expr) => {
-                if let Some(expr) = expr.expr {
-                    self.extract_literals_from_expr(*expr);
-                }
-            }
-            Expr::Verbatim(_) => unimplemented!("Expr::Verbatim"),
+    fn visit_item_static(&mut self, item: &'ast syn::ItemStatic) {
+        self.in_static = true;
+        syn::visit::visit_item_static(self, item);
+        self.in_static = false;
+    }
+
+    fn visit_item_const(&mut self, item: &'ast syn::ItemConst) {
+        self.in_const = true;
+        syn::visit::visit_item_const(self, item);
+        self.in_const = false;
+    }
+
+    fn visit_expr_if(&mut self, expr: &'ast syn::ExprIf) {
+        self.condition_depth += 1;
+        self.visit_expr(&*expr.cond);
+        self.condition_depth -= 1;
+        self.visit_block(&expr.then_branch);
+        if let Some((_, branch)) = &expr.else_branch {
+            self.visit_expr(&*branch);
         }
     }
 
-    fn extract_literals_from_pat(&mut self, pat: Pat) {
-        match pat {
-            Pat::Wild(_) | Pat::Path(_) => (),
-            Pat::Ident(pat) => {
-                if let Some((_, pat)) = pat.subpat {
-                    self.extract_literals_from_pat(*pat);
-                }
-            }
-            Pat::Struct(pat) => {
-                for pat in pat.fields {
-                    self.extract_literals_from_pat(*pat.pat);
-                }
-            }
-            Pat::TupleStruct(pat) => {
-                for pat in pat.pat.front.into_iter().chain(pat.pat.back) {
-                    self.extract_literals_from_pat(pat);
-                }
-            }
-            Pat::Tuple(pat) => {
-                for pat in pat.front.into_iter().chain(pat.back) {
-                    self.extract_literals_from_pat(pat);
-                }
-            }
-            Pat::Box(pat) => self.extract_literals_from_pat(*pat.pat),
-            Pat::Ref(pat) => self.extract_literals_from_pat(*pat.pat),
-            Pat::Lit(pat) => self.extract_literals_from_expr(*pat.expr),
-            // handling lo is enough as we can trigger that pattern with the lo element already
-            Pat::Range(pat) => self.extract_literals_from_expr(*pat.lo),
-            Pat::Slice(pat) => {
-                let pats_iter = pat
-                    .front
-                    .into_iter()
-                    .chain(pat.middle.map(|pat| *pat))
-                    .chain(pat.back);
-                for pat in pats_iter {
-                    self.extract_literals_from_pat(pat);
-                }
-            }
-            Pat::Macro(_) => (),
-            Pat::Verbatim(_) => unimplemented!("Pat::Verbatim"),
+    fn visit_expr_while(&mut self, expr: &'ast syn::ExprWhile) {
+        self.condition_depth += 1;
+        self.visit_expr(&*expr.cond);
+        self.condition_depth -= 1;
+        self.visit_block(&expr.body);
+    }
+
+    fn visit_expr_for_loop(&mut self, expr: &'ast syn::ExprForLoop) {
+        self.condition_depth += 1;
+        self.visit_expr(&*expr.expr);
+        self.condition_depth -= 1;
+        self.visit_block(&expr.body);
+    }
+
+    fn visit_expr_match(&mut self, expr: &'ast syn::ExprMatch) {
+        self.condition_depth += 1;
+        self.visit_expr(&*expr.expr);
+        self.condition_depth -= 1;
+        for it in &expr.arms {
+            self.visit_arm(it);
         }
+    }
+
+    fn visit_arm(&mut self, arm: &'ast syn::Arm) {
+        self.visit_pat(&arm.pat);
+        self.condition_depth += 1;
+        if let Some((_, guard)) = &arm.guard {
+            self.visit_expr(guard);
+        }
+        self.condition_depth -= 1;
+        self.visit_expr(&*arm.body);
+    }
+
+    fn visit_pat(&mut self, pat: &'ast syn::Pat) {
+        // Covers let-else patterns etc.
+        self.condition_depth += 1;
+        syn::visit::visit_pat(self, pat);
+        self.condition_depth -= 1;
+    }
+
+    fn visit_attribute(&mut self, _attr: &'ast syn::Attribute) {
+        // Ignore attributes, e.g. doc comments
     }
 }

--- a/fuzzer/src/scoring.rs
+++ b/fuzzer/src/scoring.rs
@@ -12,7 +12,7 @@ pub fn pearson_correlation(time_samples: &[(f64, f64)]) -> (f64, bool) {
     vec.extend(time_samples.iter().cloned().map(|(x, y)| [x, y]));
     let time_samples = Array2::from(vec);
     let time_samples = time_samples.t();
-    let corr = time_samples.pearson_correlation()[[1, 0]];
+    let corr = time_samples.pearson_correlation().expect("no time samples given")[[1, 0]];
     (corr, corr < super::ACCEPTANCE_CORRELATION)
 }
 


### PR DESCRIPTION
Some fixes and adjustments to the superlinear time fuzzer to make it work again. Found this issue with it: https://github.com/pulldown-cmark/pulldown-cmark/issues/934

- Update crates, fix source code path, add `\n` as a token
- Rewrite the literal parser using `syn::visit`
  - This should be a little simpler to maintain, as the bulk of the AST walk is handled by syn itself, while we only redefine custom behavior for some nodes

By the way, I think this component (or at least the directory) should be renamed. We currently have both `fuzz` and `fuzzer`, which is a little confusing. Bikeshedding:
- `superlinear-fuzzer`
- `perf-fuzzer`

Thoughts on this?