### PR TITLE
Add instructions on fixing fuzz build

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,25 @@
+# Fuzz targets
+
+This crate specifies fuzzing targets which are
+instrumented with [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).
+
+## Fixing fuzz build issue
+
+At the moment, building fuzz targets with default settings
+(`cargo fuzz build`) throws many errors like this:
+
+```
+: rust-lld: error: undefined symbol: __sancov_gen_.1094
+          >>> referenced by parse.3be71763e9de75d0-cgu.0
+          >>>               /home/user/projects/pulldown-cmark/target/x86_64-unknown-linux-gnu/release/deps/parse-4bac226fcf249aac.parse.3be71763e9de75d0-cgu.0.rcgu.o:(asan.module_dtor.1168)
+```
+
+The issue seems to be triggered during linking of the binaries
+with default `profile.release.lto=true` set at the workspace `Cargo.toml`
+file.
+
+To fix the build, you can override `lto` config using env variable:
+
+```bash
+$ CARGO_PROFILE_RELEASE_LTO=thin cargo fuzz run parse -- -only_ascii=1 -max_total_time=60
+```


### PR DESCRIPTION
When I was testing https://github.com/pulldown-cmark/pulldown-cmark/pull/948,
I built it directly using `cargo build` from within `fuzz` crate which worked as expected.
However, when using fuzzers with `cargo fuzz`, it overrides a lot of compilation parameters and that fails the built.

```bash
: rust-lld: error: undefined symbol: __sancov_gen_.1094
          >>> referenced by parse.3be71763e9de75d0-cgu.0
          >>>               /home/user/projects/pulldown-cmark/target/x86_64-unknown-linux-gnu/release/deps/parse-4bac226fcf249aac.parse.3be71763e9de75d0-cgu.0.rcgu.o:(asan.module_dtor.1168)
```

I spent some time investigating the issue and the easiest fix seems to be overriding `lto` config in release profile which could be done using environment variables:

```bash
CARGO_PROFILE_RELEASE_LTO=thin cargo fuzz build
```

This PR adds documentation on the issue and how to work around it. 