### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,11 @@ jobs:
     - name: Install Rust
       run: rustup default ${{ matrix.rust-version }}
     - name: Cargo build
+      if: ${{ matrix.rust-version != 'nightly' }}
       run: cargo build --verbose
+    - name: Cargo build whole workspace
+      if: ${{ matrix.rust-version == 'nightly' }}
+      run: cargo build --workspace --verbose
     - name: Cargo test
       run: cargo test --verbose
     - name: Cargo test with simd feature enabled

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,6 @@ jobs:
       matrix:
         rust-version: ['1.71.1', 'stable', 'nightly']
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: pulldown-cmark
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,28 +23,24 @@ jobs:
     - name: Install Rust
       run: rustup default ${{ matrix.rust-version }}
     - name: Cargo build
-      if: ${{ matrix.rust-version != 'nightly' }}
+      if: ${{ matrix.rust-version == '1.71.1' }}
       run: cargo build --verbose
-    - name: Cargo build whole workspace
-      if: ${{ matrix.rust-version == 'nightly' }}
+    - name: Cargo build the workspace
+      if: ${{ matrix.rust-version != '1.71.1' }}
       run: cargo build --workspace --verbose
     - name: Cargo test
+      # dos-fuzzer does not build with old rust version
+      if: ${{ matrix.rust-version == '1.71.1' }}
       run: cargo test --verbose
+    - name: Cargo test the workspace
+      if: ${{ matrix.rust-version != '1.71.1' }}
+      run: cargo test --verbose --workspace
     - name: Cargo test with simd feature enabled
       run: cargo test --features=simd,gen-tests
     - name: Cargo test with serde feature enabled
       run: cargo test --features=serde
     - name: Cargo test without default features
       run: cargo test --no-default-features
-  pulldown-cmark-escape:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: rustup default stable
-    - name: Cargo test
-      working-directory: pulldown-cmark-escape
-      run: cargo test --verbose --all
   regression:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-default-members = ["bench", "pulldown-cmark", "pulldown-cmark-escape"]
+default-members = ["pulldown-cmark", "pulldown-cmark-escape"]
 members = [
   "bench",
   "dos-fuzzer",


### PR DESCRIPTION
* Enable caching of build artifacts
  Should considerably speed up builds, especially if building `fuzz` crate.
* Clean up the job `pulldown-cmark-escape`.
  The existing job was confusingly executing workspace tests from the child dir.
* Enable build of `fuzz` and `dos-fuzzer` on every PR.