### PR TITLE
Complete the list of block item bodies

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2713,3 +2713,16 @@ Some preamble <code>foobar_raz</code>, not <code>barfoo_raz</code></dt>
 <p>This should fix:</p>
 <p>&gt; Something is wrong!</p>
 ````````````````````````````````
+
+```````````````````````````````` example
+- Item definition [it
+  ```rust
+  ```
+  stuff](https://example.com)
+.
+<ul>
+<li>Item definition [it
+<pre><code class="language-rust"></code></pre>
+stuff](https://example.com)</li>
+</ul>
+````````````````````````````````

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3236,3 +3236,20 @@ Some preamble <code>foobar_raz</code>, not <code>barfoo_raz</code></dt>
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_205() {
+    let original = r##"- Item definition [it
+  ```rust
+  ```
+  stuff](https://example.com)
+"##;
+    let expected = r##"<ul>
+<li>Item definition [it
+<pre><code class="language-rust"></code></pre>
+stuff](https://example.com)</li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
This fixes a few remaining bugs in tight lists, where you can wind up with block items nested within inlines.

The ordering of ItemBody items is designed to have a tight ASM [in godbolt](https://rust.godbolt.org/z/xza85GfG6).