### PR TITLE
Implement into_static for CowStr and Event in pulldown-cmark

### DIFF
--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -142,7 +142,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 }
             }
             let container_start = start_ix + line_start.bytes_scanned();
-            if let Some((ch, index, indent)) = line_start.scan_list_marker_with_indent(outer_indent) {
+            if let Some((ch, index, indent)) = line_start.scan_list_marker_with_indent(outer_indent)
+            {
                 let after_marker_index = start_ix + line_start.bytes_scanned();
                 self.continue_list(container_start - outer_indent, ch, index);
                 self.tree.append(Item {
@@ -194,7 +195,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 })
                 .and_then(|item| {
                     Some((
-                        line_start.scan_definition_list_definition_marker_with_indent(outer_indent)?,
+                        line_start
+                            .scan_definition_list_definition_marker_with_indent(outer_indent)?,
                         item.0,
                         item.1,
                     ))
@@ -584,7 +586,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         let body = if let Some(ItemBody::DefinitionList(_)) =
             self.tree.peek_up().map(|idx| self.tree[idx].item.body)
         {
-            if self.tree.cur().map_or(true, |idx| matches!(&self.tree[idx].item.body, ItemBody::DefinitionListDefinition(..))) {
+            if self.tree.cur().map_or(true, |idx| {
+                matches!(
+                    &self.tree[idx].item.body,
+                    ItemBody::DefinitionListDefinition(..)
+                )
+            }) {
                 // blank lines between the previous definition and this one don't count
                 self.last_line_blank = false;
                 ItemBody::MaybeDefinitionListTitle

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -120,6 +120,13 @@ impl<'a> CodeBlockKind<'a> {
     pub fn is_fenced(&self) -> bool {
         matches!(*self, CodeBlockKind::Fenced(_))
     }
+
+    pub fn into_static(self) -> CodeBlockKind<'static> {
+        match self {
+            CodeBlockKind::Indented => CodeBlockKind::Indented,
+            CodeBlockKind::Fenced(s) => CodeBlockKind::Fenced(s.into_static()),
+        }
+    }
 }
 
 /// BlockQuote kind (Note, Tip, Important, Warning, Caution).
@@ -242,6 +249,65 @@ impl<'a> Tag<'a> {
             Tag::DefinitionList => TagEnd::DefinitionList,
             Tag::DefinitionListTitle => TagEnd::DefinitionListTitle,
             Tag::DefinitionListDefinition => TagEnd::DefinitionListDefinition,
+        }
+    }
+
+    pub fn into_static(self) -> Tag<'static> {
+        match self {
+            Tag::Paragraph => Tag::Paragraph,
+            Tag::Heading {
+                level,
+                id,
+                classes,
+                attrs,
+            } => Tag::Heading {
+                level,
+                id: id.map(|s| s.into_static()),
+                classes: classes.into_iter().map(|s| s.into_static()).collect(),
+                attrs: attrs
+                    .into_iter()
+                    .map(|(k, v)| (k.into_static(), v.map(|s| s.into_static())))
+                    .collect(),
+            },
+            Tag::BlockQuote(k) => Tag::BlockQuote(k),
+            Tag::CodeBlock(kb) => Tag::CodeBlock(kb.into_static()),
+            Tag::HtmlBlock => Tag::HtmlBlock,
+            Tag::List(v) => Tag::List(v),
+            Tag::Item => Tag::Item,
+            Tag::FootnoteDefinition(a) => Tag::FootnoteDefinition(a.into_static()),
+            Tag::Table(v) => Tag::Table(v),
+            Tag::TableHead => Tag::TableHead,
+            Tag::TableRow => Tag::TableRow,
+            Tag::TableCell => Tag::TableCell,
+            Tag::Emphasis => Tag::Emphasis,
+            Tag::Strong => Tag::Strong,
+            Tag::Strikethrough => Tag::Strikethrough,
+            Tag::Link {
+                link_type,
+                dest_url,
+                title,
+                id,
+            } => Tag::Link {
+                link_type,
+                dest_url: dest_url.into_static(),
+                title: title.into_static(),
+                id: id.into_static(),
+            },
+            Tag::Image {
+                link_type,
+                dest_url,
+                title,
+                id,
+            } => Tag::Image {
+                link_type,
+                dest_url: dest_url.into_static(),
+                title: title.into_static(),
+                id: id.into_static(),
+            },
+            Tag::MetadataBlock(v) => Tag::MetadataBlock(v),
+            Tag::DefinitionList => Tag::DefinitionList,
+            Tag::DefinitionListTitle => Tag::DefinitionListTitle,
+            Tag::DefinitionListDefinition => Tag::DefinitionListDefinition,
         }
     }
 }
@@ -418,6 +484,26 @@ pub enum Event<'a> {
     Rule,
     /// A task list marker, rendered as a checkbox in HTML. Contains a true when it is checked.
     TaskListMarker(bool),
+}
+
+impl<'a> Event<'a> {
+    pub fn into_static(self) -> Event<'static> {
+        match self {
+            Event::Start(t) => Event::Start(t.into_static()),
+            Event::End(e) => Event::End(e),
+            Event::Text(s) => Event::Text(s.into_static()),
+            Event::Code(s) => Event::Code(s.into_static()),
+            Event::InlineMath(s) => Event::InlineMath(s.into_static()),
+            Event::DisplayMath(s) => Event::DisplayMath(s.into_static()),
+            Event::Html(s) => Event::Html(s.into_static()),
+            Event::InlineHtml(s) => Event::InlineHtml(s.into_static()),
+            Event::FootnoteReference(s) => Event::FootnoteReference(s.into_static()),
+            Event::SoftBreak => Event::SoftBreak,
+            Event::HardBreak => Event::HardBreak,
+            Event::Rule => Event::Rule,
+            Event::TaskListMarker(b) => Event::TaskListMarker(b),
+        }
+    }
 }
 
 /// Table column text alignment.

--- a/pulldown-cmark/src/linklabel.rs
+++ b/pulldown-cmark/src/linklabel.rs
@@ -22,7 +22,7 @@
 
 use unicase::UniCase;
 
-use crate::scanners::{is_ascii_whitespace, scan_eol, is_ascii_punctuation};
+use crate::scanners::{is_ascii_punctuation, is_ascii_whitespace, scan_eol};
 use crate::strings::CowStr;
 
 #[derive(Debug)]
@@ -134,10 +134,16 @@ pub(crate) fn scan_link_label_rest<'t>(
             text[..ix].trim_matches(asciiws).into()
         } else {
             label.push_str(&text[mark..ix]);
-            while matches!(label.as_bytes().last(), Some(&b' ' | &b'\r' | &b'\n' | &b'\t')) {
+            while matches!(
+                label.as_bytes().last(),
+                Some(&b' ' | &b'\r' | &b'\n' | &b'\t')
+            ) {
                 label.pop();
             }
-            while matches!(label.as_bytes().first(), Some(&b' ' | &b'\r' | &b'\n' | &b'\t')) {
+            while matches!(
+                label.as_bytes().first(),
+                Some(&b' ' | &b'\r' | &b'\n' | &b'\t')
+            ) {
                 label.remove(0);
             }
             label.into()

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -471,7 +471,8 @@ impl<'input, F: BrokenLinkCallback<'input>> Parser<'input, F> {
                     let result = if self.math_delims.is_populated() {
                         // we have previously scanned all math environment delimiters,
                         // so we can reuse that work
-                        self.math_delims.find(&self.tree, cur_ix, is_display, brace_context)
+                        self.math_delims
+                            .find(&self.tree, cur_ix, is_display, brace_context)
                     } else {
                         // we haven't previously scanned all math delimiters,
                         // so walk the AST
@@ -1685,6 +1686,16 @@ pub struct LinkDef<'a> {
     pub dest: CowStr<'a>,
     pub title: Option<CowStr<'a>>,
     pub span: Range<usize>,
+}
+
+impl<'a> LinkDef<'a> {
+    pub fn into_static(self) -> LinkDef<'static> {
+        LinkDef {
+            dest: self.dest.into_static(),
+            title: self.title.map(|s| s.into_static()),
+            span: self.span,
+        }
+    }
 }
 
 /// Contains the destination URL, title and source span of a reference definition.

--- a/pulldown-cmark/src/scanners.rs
+++ b/pulldown-cmark/src/scanners.rs
@@ -279,7 +279,10 @@ impl<'a> LineStart<'a> {
     ///
     /// Return value is the amount of indentation, or `None` if it's not a
     /// definition list marker.
-    pub(crate) fn scan_definition_list_definition_marker_with_indent(&mut self, indent: usize) -> Option<usize> {
+    pub(crate) fn scan_definition_list_definition_marker_with_indent(
+        &mut self,
+        indent: usize,
+    ) -> Option<usize> {
         let save = self.clone();
         if self.scan_ch(b':') {
             let remaining = 4 - (indent + 1);
@@ -295,7 +298,10 @@ impl<'a> LineStart<'a> {
     /// Return value is the character, the start index, and the indent in spaces.
     /// For ordered list markers, the character will be one of b'.' or b')'. For
     /// bullet list markers, it will be one of b'-', b'+', or b'*'.
-    pub(crate) fn scan_list_marker_with_indent(&mut self, indent: usize) -> Option<(u8, u64, usize)> {
+    pub(crate) fn scan_list_marker_with_indent(
+        &mut self,
+        indent: usize,
+    ) -> Option<(u8, u64, usize)> {
         let save = self.clone();
         if self.ix < self.bytes.len() {
             let c = self.bytes[self.ix];
@@ -1008,7 +1014,13 @@ fn scan_attribute(
     let ix_after_attribute = ix;
     ix = scan_whitespace_with_newline_handler_without_buffer(data, ix, newline_handler)?;
     if scan_ch(&data[ix..], b'=') == 1 {
-        ix = scan_whitespace_with_newline_handler(data, ix_after_attribute, newline_handler, buffer, buffer_ix)?;
+        ix = scan_whitespace_with_newline_handler(
+            data,
+            ix_after_attribute,
+            newline_handler,
+            buffer,
+            buffer_ix,
+        )?;
         ix += 1;
         ix = scan_whitespace_with_newline_handler(data, ix, newline_handler, buffer, buffer_ix)?;
         ix = scan_attribute_value(data, ix, newline_handler, buffer, buffer_ix)?;

--- a/pulldown-cmark/src/strings.rs
+++ b/pulldown-cmark/src/strings.rs
@@ -262,7 +262,14 @@ impl<'a> CowStr<'a> {
     }
 
     pub fn into_static(self) -> CowStr<'static> {
-        self.into_string().into()
+        match self {
+            CowStr::Boxed(b) => CowStr::Boxed(b),
+            CowStr::Borrowed(b) => match InlineStr::try_from(b) {
+                Ok(inline) => CowStr::Inlined(inline),
+                Err(_) => CowStr::Boxed(b.into()),
+            },
+            CowStr::Inlined(s) => CowStr::Inlined(s),
+        }
     }
 }
 

--- a/pulldown-cmark/src/strings.rs
+++ b/pulldown-cmark/src/strings.rs
@@ -260,6 +260,10 @@ impl<'a> CowStr<'a> {
             CowStr::Inlined(s) => s.deref().to_owned(),
         }
     }
+
+    pub fn into_static(self) -> CowStr<'static> {
+        self.into_string().into()
+    }
 }
 
 impl<'a> fmt::Display for CowStr<'a> {


### PR DESCRIPTION
Fixes: https://github.com/pulldown-cmark/pulldown-cmark/issues/625

I found that we cannot implement ToOwned, but I found the following code:
```rust
impl<'a> BrokenLink<'a> {
    /// Moves the link into version with a static lifetime.
    ///
    /// The `reference` member is cloned to a Boxed or Inline version.
    pub fn into_static(self) -> BrokenLink<'static> {
        BrokenLink {
            span: self.span.clone(),
            link_type: self.link_type,
            reference: self.reference.into_string().into(),
        }
    }
}
```
So, I added similar implementations for other types with lifetimes so we can use them more freely.