### PR TITLE
fix: do not strip trailing space when it is for blockquote marker

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2726,3 +2726,42 @@ Some preamble <code>foobar_raz</code>, not <code>barfoo_raz</code></dt>
 stuff](https://example.com)</li>
 </ul>
 ````````````````````````````````
+
+ISSUE #963
+
+```````````````````````````````` example
+foo
+{.class}
+===
+
+> foo
+> {.class}
+> ===
+>
+> > foo
+> > {.class}
+> > ===
+
+* > foo
+  > {.class}
+  > ===
+.
+<h1 class="class">foo
+</h1>
+<blockquote>
+<h1 class="class">foo
+</h1>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+</blockquote>
+<ul>
+<li>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+</li>
+</ul>
+````````````````````````````````

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3253,3 +3253,44 @@ stuff](https://example.com)</li>
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_206() {
+    let original = r##"foo
+{.class}
+===
+
+> foo
+> {.class}
+> ===
+>
+> > foo
+> > {.class}
+> > ===
+
+* > foo
+  > {.class}
+  > ===
+"##;
+    let expected = r##"<h1 class="class">foo
+</h1>
+<blockquote>
+<h1 class="class">foo
+</h1>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+</blockquote>
+<ul>
+<li>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+</li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
Fix #963

The parser strips trailing spaces after removing the attributes from the header. However the issue was that a whitespace for blockquote marker `> ` should not be removed.

For example, when parsing

```
>･foo
>･{.foo}
>･======
```

(`･` represents a space)

The parser strips the attributes

```
>･foo
>･
>･======
```

and strips the trailing space at the second line

```
>･foo
>
>･======
```