### PR TITLE
Respect line starts when trimming header endings

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2726,3 +2726,59 @@ Some preamble <code>foobar_raz</code>, not <code>barfoo_raz</code></dt>
 stuff](https://example.com)</li>
 </ul>
 ````````````````````````````````
+
+ISSUE #963
+
+```````````````````````````````` example
+foo
+{.class}
+===
+
+> foo
+> {.class}
+> ===
+>
+> > foo
+> > {.class}
+> > ===
+
+* > foo
+  > {.class}
+  > ===
+
+> foo
+>→{.class}
+>→===
+.
+<h1 class="class">foo
+</h1>
+<blockquote>
+<h1 class="class">foo
+</h1>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+</blockquote>
+<ul>
+<li>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+</li>
+</ul>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example
+the trailing space after the &gt; should be stripped
+    > {.bar}
+===
+.
+<h1 class="bar">the trailing space after the &gt; should be stripped
+&gt;</h1>
+````````````````````````````````

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -725,24 +725,29 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 content_end
             } else {
                 let mut last_line_start = header_start;
-                loop {
-                    let next_line_start = last_line_start + scan_nextline(&bytes[last_line_start..content_end]);
-                    if next_line_start >= content_end {
-                        break;
+                if attrs.is_some() {
+                    loop {
+                        let next_line_start =
+                            last_line_start + scan_nextline(&bytes[last_line_start..content_end]);
+                        if next_line_start >= content_end {
+                            break;
+                        }
+                        let mut line_start = LineStart::new(&bytes[next_line_start..content_end]);
+                        if scan_containers(
+                            &self.tree,
+                            &mut line_start,
+                            self.options.has_gfm_footnotes(),
+                        ) != self.tree.spine_len()
+                        {
+                            break;
+                        }
+                        last_line_start = next_line_start + line_start.bytes_scanned();
                     }
-                    let mut line_start = LineStart::new(&bytes[next_line_start..content_end]);
-                    if scan_containers(
-                        &self.tree,
-                        &mut line_start,
-                        self.options.has_gfm_footnotes(),
-                    ) != self.tree.spine_len()
-                    {
-                        break;
-                    }
-                    last_line_start = next_line_start + line_start.bytes_scanned();
                 }
-                let trailing_ws =
-                    scan_rev_while(&bytes[last_line_start..content_end], is_ascii_whitespace_no_nl);
+                let trailing_ws = scan_rev_while(
+                    &bytes[last_line_start..content_end],
+                    is_ascii_whitespace_no_nl,
+                );
                 content_end - trailing_ws
             };
 

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3253,3 +3253,65 @@ stuff](https://example.com)</li>
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_206() {
+    let original = r##"foo
+{.class}
+===
+
+> foo
+> {.class}
+> ===
+>
+> > foo
+> > {.class}
+> > ===
+
+* > foo
+  > {.class}
+  > ===
+
+> foo
+>	{.class}
+>	===
+"##;
+    let expected = r##"<h1 class="class">foo
+</h1>
+<blockquote>
+<h1 class="class">foo
+</h1>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+</blockquote>
+<ul>
+<li>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+</li>
+</ul>
+<blockquote>
+<h1 class="class">foo
+</h1>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_207() {
+    let original = r##"the trailing space after the &gt; should be stripped
+    > {.bar}
+===
+"##;
+    let expected = r##"<h1 class="bar">the trailing space after the &gt; should be stripped
+&gt;</h1>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
This prevents it from trying to trim whitespace that's part of a block quote or list marker.

Fixes https://github.com/pulldown-cmark/pulldown-cmark/issues/963

This is an alternative fix to https://github.com/pulldown-cmark/pulldown-cmark/pull/968 that handles a few corner cases better. As @rhysd figured out the root cause, the problem is that the code stripped a space that was actually part of the block quote marker, attempting to trim the text node beyond its starting point.