### PR TITLE
Factor duplicate code out of parsers

### DIFF
--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -104,16 +104,6 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     }
                 }
             }
-
-            // Footnote definitions of the form
-            // [^bar]:
-            // * anything really
-            let container_start = start_ix + line_start.bytes_scanned();
-            if let Some(bytecount) = self.parse_footnote(container_start) {
-                start_ix = container_start + bytecount;
-                start_ix += scan_blank_line(&bytes[start_ix..]).unwrap_or(0);
-                line_start = LineStart::new(&bytes[start_ix..]);
-            }
         }
 
         // Process new containers
@@ -124,15 +114,16 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 line_start = save;
                 break;
             }
-            if self.options.has_gfm_footnotes()
-                || self.options.contains(Options::ENABLE_OLD_FOOTNOTES)
-            {
-                // Footnote definitions of the form
-                // [^bar]:
-                //     * anything really
+            if self.options.contains(Options::ENABLE_FOOTNOTES) {
+                // Footnote definitions
                 let container_start = start_ix + line_start.bytes_scanned();
                 if let Some(bytecount) = self.parse_footnote(container_start) {
                     start_ix = container_start + bytecount;
+                    if self.options.contains(Options::ENABLE_OLD_FOOTNOTES) {
+                        // gfm footnotes need indented, but old footnotes don't
+                        // handle this, old footnotes treat the next line as part of the current line
+                        start_ix += scan_blank_line(&bytes[start_ix..]).unwrap_or(0);
+                    }
                     line_start = LineStart::new(&bytes[start_ix..]);
                     continue;
                 }
@@ -400,23 +391,13 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             // ```
             if let Some(nl) = scan_blank_line(&bytes[ix..]) {
                 ix += nl;
-                let mut lazy_line_start = LineStart::new(&bytes[ix..]);
-                let current_container =
-                    scan_containers(&self.tree, &mut lazy_line_start, self.options)
-                        == self.tree.spine_len();
-                if !lazy_line_start.scan_space(4)
-                    && self.scan_paragraph_interrupt(
-                        &bytes[ix + lazy_line_start.bytes_scanned()..],
-                        current_container,
-                    )
-                {
-                    self.finish_list(start_ix);
-                    return ix;
-                } else {
-                    line_start = lazy_line_start;
-                    line_start.scan_all_space();
-                    start_ix = ix;
-                }
+            } else {
+                self.finish_list(start_ix);
+                return ix;
+            }
+            if let Some(lazy_line_start) = self.scan_next_line_or_lazy_continuation(&bytes[ix..]) {
+                line_start = lazy_line_start;
+                start_ix = ix;
             } else {
                 self.finish_list(start_ix);
                 return ix;
@@ -426,6 +407,29 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         let ix = start_ix + line_start.bytes_scanned();
 
         self.parse_paragraph(ix)
+    }
+
+    /// footnote definitions and GFM quote markers can be "interrupted"
+    /// like paragraphs, but otherwise can't have other blocks after them.
+    ///
+    /// Call this at the end of the line to parse that. If it succeeeds,
+    /// this returns the LineStart for the new line.
+    fn scan_next_line_or_lazy_continuation<'input>(
+        &mut self,
+        bytes: &'input [u8],
+    ) -> Option<LineStart<'input>> {
+        let mut line_start = LineStart::new(bytes);
+        let current_container =
+            scan_containers(&self.tree, &mut line_start, self.options) == self.tree.spine_len();
+        if !line_start.scan_space(4)
+            && self
+                .scan_paragraph_interrupt(&bytes[line_start.bytes_scanned()..], current_container)
+        {
+            None
+        } else {
+            line_start.scan_all_space();
+            Some(line_start)
+        }
     }
 
     /// Returns the offset of the first line after the table.

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -90,11 +90,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         self.brace_context_stack.clear();
         self.brace_context_next = 0;
 
-        let i = scan_containers(
-            &self.tree,
-            &mut line_start,
-            self.options.has_gfm_footnotes(),
-        );
+        let i = scan_containers(&self.tree, &mut line_start, self.options);
         for _ in i..self.tree.spine_len() {
             self.pop(start_ix);
         }
@@ -260,11 +256,9 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     // and break out if we can't re-scan all of them
                     let ix = start_ix + line_start.bytes_scanned();
                     let mut lazy_line_start = LineStart::new(&bytes[ix..]);
-                    let current_container = scan_containers(
-                        &self.tree,
-                        &mut lazy_line_start,
-                        self.options.has_gfm_footnotes(),
-                    ) == self.tree.spine_len();
+                    let current_container =
+                        scan_containers(&self.tree, &mut lazy_line_start, self.options)
+                            == self.tree.spine_len();
                     if !lazy_line_start.scan_space(4)
                         && self.scan_paragraph_interrupt(
                             &bytes[ix + lazy_line_start.bytes_scanned()..],
@@ -407,11 +401,9 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             if let Some(nl) = scan_blank_line(&bytes[ix..]) {
                 ix += nl;
                 let mut lazy_line_start = LineStart::new(&bytes[ix..]);
-                let current_container = scan_containers(
-                    &self.tree,
-                    &mut lazy_line_start,
-                    self.options.has_gfm_footnotes(),
-                ) == self.tree.spine_len();
+                let current_container =
+                    scan_containers(&self.tree, &mut lazy_line_start, self.options)
+                        == self.tree.spine_len();
                 if !lazy_line_start.scan_space(4)
                     && self.scan_paragraph_interrupt(
                         &bytes[ix + lazy_line_start.bytes_scanned()..],
@@ -557,11 +549,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
     ) -> Option<(usize, TreeIndex)> {
         let bytes = self.text.as_bytes();
         let mut line_start = LineStart::new(&bytes[ix..]);
-        let current_container = scan_containers(
-            &self.tree,
-            &mut line_start,
-            self.options.has_gfm_footnotes(),
-        ) == self.tree.spine_len();
+        let current_container =
+            scan_containers(&self.tree, &mut line_start, self.options) == self.tree.spine_len();
         if !current_container {
             return None;
         }
@@ -648,11 +637,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
 
             ix = next_ix;
             let mut line_start = LineStart::new(&bytes[ix..]);
-            let current_container = scan_containers(
-                &self.tree,
-                &mut line_start,
-                self.options.has_gfm_footnotes(),
-            ) == self.tree.spine_len();
+            let current_container =
+                scan_containers(&self.tree, &mut line_start, self.options) == self.tree.spine_len();
             let trailing_backslash_pos = match brk {
                 Some(Item {
                     start,
@@ -740,11 +726,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                             break;
                         }
                         let mut line_start = LineStart::new(&bytes[next_line_start..content_end]);
-                        if scan_containers(
-                            &self.tree,
-                            &mut line_start,
-                            self.options.has_gfm_footnotes(),
-                        ) != self.tree.spine_len()
+                        if scan_containers(&self.tree, &mut line_start, self.options)
+                            != self.tree.spine_len()
                         {
                             break;
                         }
@@ -826,11 +809,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         // check if we may be parsing a table
                         let next_line_ix = ix + eol_bytes;
                         let mut line_start = LineStart::new(&bytes[next_line_ix..]);
-                        if scan_containers(
-                            &self.tree,
-                            &mut line_start,
-                            self.options.has_gfm_footnotes(),
-                        ) == self.tree.spine_len()
+                        if scan_containers(&self.tree, &mut line_start, self.options)
+                            == self.tree.spine_len()
                         {
                             let table_head_ix = next_line_ix + line_start.bytes_scanned();
                             let (table_head_bytes, alignment) =
@@ -1256,11 +1236,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             self.append_html_line(remaining_space.max(indent), line_start_ix, ix);
 
             let mut line_start = LineStart::new(&bytes[ix..]);
-            let n_containers = scan_containers(
-                &self.tree,
-                &mut line_start,
-                self.options.has_gfm_footnotes(),
-            );
+            let n_containers = scan_containers(&self.tree, &mut line_start, self.options);
             if n_containers < self.tree.spine_len() {
                 end_ix = ix;
                 break;
@@ -1309,11 +1285,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             self.append_html_line(remaining_space.max(indent), line_start_ix, ix);
 
             let mut line_start = LineStart::new(&bytes[ix..]);
-            let n_containers = scan_containers(
-                &self.tree,
-                &mut line_start,
-                self.options.has_gfm_footnotes(),
-            );
+            let n_containers = scan_containers(&self.tree, &mut line_start, self.options);
             if n_containers < self.tree.spine_len() || line_start.is_at_eol() {
                 end_ix = ix;
                 break;
@@ -1360,11 +1332,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             }
 
             let mut line_start = LineStart::new(&bytes[ix..]);
-            let n_containers = scan_containers(
-                &self.tree,
-                &mut line_start,
-                self.options.has_gfm_footnotes(),
-            );
+            let n_containers = scan_containers(&self.tree, &mut line_start, self.options);
             if n_containers < self.tree.spine_len()
                 || !(line_start.scan_space(4) || line_start.is_at_eol())
             {
@@ -1411,11 +1379,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         self.tree.push();
         loop {
             let mut line_start = LineStart::new(&bytes[ix..]);
-            let n_containers = scan_containers(
-                &self.tree,
-                &mut line_start,
-                self.options.has_gfm_footnotes(),
-            );
+            let n_containers = scan_containers(&self.tree, &mut line_start, self.options);
             if n_containers < self.tree.spine_len() {
                 // this line will get parsed again as not being part of the code
                 // if it's blank, it should be parsed as a blank line
@@ -1459,11 +1423,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         self.tree.push();
         loop {
             let mut line_start = LineStart::new(&bytes[ix..]);
-            let n_containers = scan_containers(
-                &self.tree,
-                &mut line_start,
-                self.options.has_gfm_footnotes(),
-            );
+            let n_containers = scan_containers(&self.tree, &mut line_start, self.options);
             if n_containers < self.tree.spine_len() {
                 break;
             }
@@ -1778,11 +1738,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             &self.text[start..],
             &|bytes| {
                 let mut line_start = LineStart::new(bytes);
-                let current_container = scan_containers(
-                    &self.tree,
-                    &mut line_start,
-                    self.options.has_gfm_footnotes(),
-                ) == self.tree.spine_len();
+                let current_container = scan_containers(&self.tree, &mut line_start, self.options)
+                    == self.tree.spine_len();
                 if line_start.scan_space(4) {
                     return Some(line_start.bytes_scanned());
                 }
@@ -1832,11 +1789,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 break;
             }
             let mut line_start = LineStart::new(&bytes[i..]);
-            let current_container = scan_containers(
-                &self.tree,
-                &mut line_start,
-                self.options.has_gfm_footnotes(),
-            ) == self.tree.spine_len();
+            let current_container =
+                scan_containers(&self.tree, &mut line_start, self.options) == self.tree.spine_len();
             if !line_start.scan_space(4) {
                 let suffix = &bytes[i + line_start.bytes_scanned()..];
                 if self.scan_paragraph_interrupt(suffix, current_container)
@@ -1894,11 +1848,9 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         bytecount += 1;
                     }
                     let mut line_start = LineStart::new(&bytes[bytecount..]);
-                    let current_container = scan_containers(
-                        &self.tree,
-                        &mut line_start,
-                        self.options.has_gfm_footnotes(),
-                    ) == self.tree.spine_len();
+                    let current_container =
+                        scan_containers(&self.tree, &mut line_start, self.options)
+                            == self.tree.spine_len();
                     if !line_start.scan_space(4) {
                         let suffix = &bytes[bytecount + line_start.bytes_scanned()..];
                         if self.scan_paragraph_interrupt(suffix, current_container)
@@ -2073,12 +2025,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         //     ^
         //     | need to skip over the `>` when checking for the table
         let mut line_start = LineStart::new(&bytes[next_line_ix..]);
-        if scan_containers(
-            &self.tree,
-            &mut line_start,
-            self.options.has_gfm_footnotes(),
-        ) != self.tree.spine_len()
-        {
+        if scan_containers(&self.tree, &mut line_start, self.options) != self.tree.spine_len() {
             return false;
         }
         let table_head_ix = next_line_ix + line_start.bytes_scanned();


### PR DESCRIPTION
This PR has miscellaneous refactoring, to reduce duplicate source code and generated code size:

* It introduces a couple helper functions, `skip_container_prefixes` and `scan_next_line_or_lazy_continuation`, to reduce code duplication.
* It passes `Options` itself down instead of `bool`, to prevent some potentially very easy mixups.
* It lifts some bound checked slices outside the loop, particularly in cases where I checked (using `cargo-show-asm`) that the compiler couldn't see it.