### PR TITLE
Ensure "parse" fuzz target covers all options

### DIFF
--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -2,60 +2,15 @@
 use libfuzzer_sys::fuzz_target;
 
 use libfuzzer_sys::arbitrary::{self, Arbitrary};
-use pulldown_cmark::Options;
 
 #[derive(Debug, Arbitrary)]
 struct FuzzingInput<'a> {
+    options: u32,
     markdown: &'a str,
-    tables: bool,
-    footnotes: bool,
-    strikethrough: bool,
-    tasklists: bool,
-    smart_punctuation: bool,
-    heading_attributes: bool,
-    metadata_block: bool,
-    math: bool,
-    gfm: bool,
 }
 
 fuzz_target!(|data: FuzzingInput<'_>| {
-    let mut opts = pulldown_cmark::Options::empty();
-
-    if data.tables {
-        opts.insert(Options::ENABLE_TABLES);
-    }
-
-    if data.footnotes {
-        opts.insert(Options::ENABLE_FOOTNOTES);
-    }
-
-    if data.strikethrough {
-        opts.insert(Options::ENABLE_STRIKETHROUGH);
-    }
-
-    if data.tasklists {
-        opts.insert(Options::ENABLE_TASKLISTS);
-    }
-
-    if data.smart_punctuation {
-        opts.insert(Options::ENABLE_SMART_PUNCTUATION);
-    }
-
-    if data.heading_attributes {
-        opts.insert(Options::ENABLE_HEADING_ATTRIBUTES);
-    }
-
-    if data.metadata_block {
-        opts.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
-    }
-
-    if data.math {
-        opts.insert(Options::ENABLE_MATH);
-    }
-
-    if data.gfm {
-        opts.insert(Options::ENABLE_GFM);
-    }
+    let opts = pulldown_cmark::Options::from_bits_truncate(data.options);
 
     for _ in pulldown_cmark::Parser::new_ext(data.markdown, opts) {}
 });


### PR DESCRIPTION
The fuzz target `parse.rs` (intended to find crashes/panics) was missing some newer options.

Change to use `Options::from_bits_truncate` to generate arbitrary combinations of all options, current and future.

Not sure if the field order in the struct makes much difference, but I figured it's better to have the fixed length field first, so it doesn't move around and change unintentionally.

Tried it out, and it found #973 in under a minute (on v0.12.2 before the fix was merged).