### PR TITLE
Add `utils::character_reference`

### DIFF
--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -1093,7 +1093,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     LoopInstruction::ContinueAndSkip(0)
                 }
                 b'&' => match scan_entity(&bytes[ix..]) {
-                    (n, Some(value)) => {
+                    Some((n, value)) => {
                         self.tree.append_text(begin_text, ix, backslash_escaped);
                         backslash_escaped = false;
                         self.tree.append(Item {
@@ -1104,7 +1104,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         begin_text = ix + n;
                         LoopInstruction::ContinueAndSkip(n - 1)
                     }
-                    _ => LoopInstruction::ContinueAndSkip(0),
+                    None => LoopInstruction::ContinueAndSkip(0),
                 },
                 b'|' => {
                     if ix != 0 && bytes[ix - 1] == b'\\' {

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -1073,7 +1073,7 @@ impl<'input, F: BrokenLinkCallback<'input>> Parser<'input, F> {
                 }
             }
             if c == b'&' {
-                if let (n, Some(value)) = scan_entity(&bytes[i..]) {
+                if let Some((n, value)) = scan_entity(&bytes[i..]) {
                     title.push_str(&text[mark..i]);
                     title.push_str(&value);
                     i += n;

--- a/pulldown-cmark/src/utils.rs
+++ b/pulldown-cmark/src/utils.rs
@@ -132,6 +132,42 @@ where
     }
 }
 
+/// Resolve a HTML [character reference], otherwise known as an entity.
+///
+/// There are three kinds of character reference:
+/// - Named, e.g. `&amp;`.
+///   The complete list of named references is given [in the HTML standard][list]
+///   and is also available [as a JSON file][JSON].
+/// - Decimal, e.g. `&#38;`,
+///   where the number is the Unicode codepoint of the character in base 10.
+/// - Hexadecimal, e.g. `&#x26;`,
+///   where the number is the Unicode codepoint of the character in base 16.
+///
+/// If the given slice starts with a character reference,
+/// this function returns `Some` with
+/// the length of the character reference in bytes
+/// and the character itself.
+/// Otherwise, `None` is returned.
+///
+/// # Examples
+///
+/// ```
+/// # use pulldown_cmark::utils::character_reference;
+/// assert_eq!(character_reference(b"&amp;"), Some((5, "&".into())));
+/// assert_eq!(character_reference(b"&#38;"), Some((5, "&".into())));
+/// assert_eq!(character_reference(b"&#x26;"), Some((6, "&".into())));
+/// ```
+/// [character reference]: https://html.spec.whatwg.org/multipage/syntax.html#character-references
+/// [list]: https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references
+/// [JSON]: https://html.spec.whatwg.org/entities.json
+pub fn character_reference(bytes: &[u8]) -> Option<(usize, CowStr<'static>)> {
+    // `scan_entity` doesn't bother checking the first byte, so we do it ourselves.
+    if bytes.first() != Some(&b'&') {
+        return None;
+    }
+    crate::scanners::scan_entity(bytes)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
I am a consumer of this crate, but I’m not outputting HTML, and I would like to transform `InlineHtml` and `HtmlBlock` nodes according to my own needs. Writing a small HTML parser myself is easy enough, but `pulldown-cmark` already has [the large table required to resolved named HTML entities](https://github.com/pulldown-cmark/pulldown-cmark/blob/master/pulldown-cmark/src/entities.rs), and for binary size’s sake I’d prefer to avoid duplicating all of this in my own code.

Therefore, this feature request exposes the functionality of resolving HTML character references in the public API of the crate, via the `utils` module.

While it may be nice to expose more HTML parsing, such an API would be more subjective and would be hard to make fit everybody’s needs. By contrast, this function is minimal and self-contained, and has legitimate disadvantages to users rolling their own versions of.