### PR TITLE
Fix OOB access due to erroneous shift in process_mask

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -19,5 +19,8 @@ harness = false
 [dependencies]
 pulldown-cmark = { path = "../pulldown-cmark" }
 
+[features]
+simd = [ "pulldown-cmark/simd" ]
+
 [dev-dependencies]
 criterion = "0.5.1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,6 +22,9 @@ urlencoding = "2.1.2"
 [dependencies.pulldown-cmark]
 path = "../pulldown-cmark"
 
+[features]
+simd = [ "pulldown-cmark/simd" ]
+
 [[bin]]
 name = "parse"
 path = "fuzz_targets/parse.rs"

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -2722,7 +2722,11 @@ mod simd {
             match callback(offset, *bytes.get_unchecked(offset)) {
                 LoopInstruction::ContinueAndSkip(skip) => {
                     offset += skip + 1;
-                    mask = mask.wrapping_shr((skip + 1 + mask_ix) as u32);
+                    let shift = skip + 1 + mask_ix;
+                    if shift >= 32 {
+                        break;
+                    }
+                    mask >>= shift;
                 }
                 LoopInstruction::BreakAtWith(ix, val) => return Err((ix, val)),
             }

--- a/pulldown-cmark/tests/errors.rs
+++ b/pulldown-cmark/tests/errors.rs
@@ -138,3 +138,8 @@ fn test_bad_slice_b() {
 fn test_bad_slice_unicode() {
     parse("><a a=\n毿>")
 }
+
+#[test]
+fn test_simd_wrapping_shr_issue_651() {
+    parse("`````````````````````````````````x`");
+}


### PR DESCRIPTION
This was changed to `wrapping_shr` in #652, but that is not correct. If the shift is too large, we should stop iterating the mask.

Fixes #651

Also added a `simd` pass-through feature to bench & fuzz for easier testing w/ SIMD.