### PR TITLE
Stop using scan_ch when get will do

### DIFF
--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -1705,7 +1705,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             return None;
         }
         i += 2;
-        if scan_ch(&bytes[i..], b':') == 0 {
+        if bytes.get(i) != Some(&b':') {
             return None;
         }
         i += 1;
@@ -1762,12 +1762,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
     /// Returns number of bytes scanned, label and definition on success.
     fn parse_refdef_total(&mut self, start: usize) -> Option<(usize, LinkLabel<'a>, LinkDef<'a>)> {
         let bytes = &self.text.as_bytes()[start..];
-        if scan_ch(bytes, b'[') == 0 {
+        if bytes.get(0) != Some(&b'[') {
             return None;
         }
         let (mut i, label) = self.parse_refdef_label(start + 1)?;
         i += 1;
-        if scan_ch(&bytes[i..], b':') == 0 {
+        if bytes.get(i) != Some(&b':') {
             return None;
         }
         i += 1;

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -1158,7 +1158,7 @@ impl<'input, F: BrokenLinkCallback<'input>> Parser<'input, F> {
         mut ix: usize,
         node: Option<TreeIndex>,
     ) -> Option<(usize, CowStr<'input>, CowStr<'input>)> {
-        if scan_ch(&underlying.as_bytes()[ix..], b'(') == 0 {
+        if underlying.as_bytes().get(ix) != Some(&b'(') {
             return None;
         }
         ix += 1;
@@ -1191,7 +1191,7 @@ impl<'input, F: BrokenLinkCallback<'input>> Parser<'input, F> {
         } else {
             "".into()
         };
-        if scan_ch(&underlying.as_bytes()[ix..], b')') == 0 {
+        if underlying.as_bytes().get(ix) != Some(&b')') {
             return None;
         }
         ix += 1;


### PR DESCRIPTION
That scanner, which returns `usize`, makes sense when actual offset arithmetic is being done. But it's overkill for checking if a character exists.

Since `slice::get` is in the standard library, use that.