### PR TITLE
Added a WASM build step to github actions #1005

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,3 +54,8 @@ jobs:
     - name: Check benchmarks are not broken
       working-directory: bench
       run: cargo check --benches
+    # Make sure the WASM target builds for the main package
+    - name: Add WASM target
+      run: rustup target add wasm32-unknown-unknown
+    - name: Build WASM target
+      run: cargo build --package pulldown-cmark --target wasm32-unknown-unknown


### PR DESCRIPTION
This PR adds a build step at the end of the regression section to ensure the main library builds for `wasm32-unknown-unknown` target.

`wasm32-unknown-unknown` targets NodeJS, Deno, web browsers and other WASM execution environments.

Closes #1005 

### Testing

I successfully ran this action in the fork.

It added 30s on one run and 4s on another.

![image](https://github.com/user-attachments/assets/84a639db-e107-42bc-8acd-acff125fb26b)

Logs:
```
2025-01-11T21:53:06.6655407Z ##[group]Run rustup target add wasm32-unknown-unknown
2025-01-11T21:53:06.6655778Z [36;1mrustup target add wasm32-unknown-unknown[0m
2025-01-11T21:53:06.6682231Z shell: /usr/bin/bash -e {0}
2025-01-11T21:53:06.6682448Z env:
2025-01-11T21:53:06.6682634Z   CARGO_TERM_COLOR: always
2025-01-11T21:53:06.6683021Z   RUSTFLAGS: -D warnings
2025-01-11T21:53:06.6683234Z   RUST_BACKTRACE: 1
2025-01-11T21:53:06.6683408Z ##[endgroup]
2025-01-11T21:53:06.7820680Z info: downloading component 'rust-std' for 'wasm32-unknown-unknown'
2025-01-11T21:53:06.9257183Z info: installing component 'rust-std' for 'wasm32-unknown-unknown'
2025-01-11T21:53:08.1920485Z ##[group]Run cargo build --package pulldown-cmark --target wasm32-unknown-unknown
2025-01-11T21:53:08.1921060Z [36;1mcargo build --package pulldown-cmark --target wasm32-unknown-unknown[0m
2025-01-11T21:53:08.1946758Z shell: /usr/bin/bash -e {0}
2025-01-11T21:53:08.1946977Z env:
2025-01-11T21:53:08.1947153Z   CARGO_TERM_COLOR: always
2025-01-11T21:53:08.1947363Z   RUSTFLAGS: -D warnings
2025-01-11T21:53:08.1947568Z   RUST_BACKTRACE: 1
2025-01-11T21:53:08.1947748Z ##[endgroup]
2025-01-11T21:53:08.4037911Z [1m[32m Downloading[0m crates ...
2025-01-11T21:53:08.4464591Z [1m[32m  Downloaded[0m bincode v1.3.3
2025-01-11T21:53:08.4533726Z [1m[32m Downloading[0m crates ...
2025-01-11T21:53:08.4697416Z [1m[32m  Downloaded[0m lazy_static v1.5.0
2025-01-11T21:53:08.4855083Z [1m[32m   Compiling[0m version_check v0.9.5
2025-01-11T21:53:08.4855675Z [1m[32m   Compiling[0m unicode-width v0.1.14
2025-01-11T21:53:08.4859546Z [1m[32m   Compiling[0m pulldown-cmark v0.12.2 (/home/runner/work/pulldown-cmark/pulldown-cmark/pulldown-cmark)
2025-01-11T21:53:08.4860949Z [1m[32m   Compiling[0m pulldown-cmark-escape v0.11.0 (/home/runner/work/pulldown-cmark/pulldown-cmark/pulldown-cmark-escape)
2025-01-11T21:53:08.6429802Z [1m[32m   Compiling[0m getopts v0.2.21
2025-01-11T21:53:08.7055930Z [1m[32m   Compiling[0m memchr v2.7.4
2025-01-11T21:53:08.7611804Z [1m[32m   Compiling[0m bitflags v2.6.0
2025-01-11T21:53:08.7923412Z [1m[32m   Compiling[0m unicase v2.7.0
2025-01-11T21:53:10.9217085Z [1m[32m    Finished[0m `dev` profile [unoptimized + debuginfo] target(s) in 2.68s
```

