### PR TITLE
docs: Added a doc-comment for ENABLE_SMART_PUNCTUATION option.

### DIFF
--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -559,6 +559,11 @@ bitflags::bitflags! {
         const ENABLE_FOOTNOTES = 1 << 2;
         const ENABLE_STRIKETHROUGH = 1 << 3;
         const ENABLE_TASKLISTS = 1 << 4;
+        /// Enables replacement of ASCII punctuation characters with 
+        /// Unicode ligatures and smart quotes.  
+        /// This includes replacing `--` with `—`, `---` with `—`, `...` with `…`,
+        /// `"quote"` with `“quote”`, and `'quote'` with `‘quote’`.  
+        /// The replacement takes place during the parsing of the document.
         const ENABLE_SMART_PUNCTUATION = 1 << 5;
         /// Extension to allow headings to have ID and classes.
         ///

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -559,10 +559,12 @@ bitflags::bitflags! {
         const ENABLE_FOOTNOTES = 1 << 2;
         const ENABLE_STRIKETHROUGH = 1 << 3;
         const ENABLE_TASKLISTS = 1 << 4;
-        /// Enables replacement of ASCII punctuation characters with 
-        /// Unicode ligatures and smart quotes.  
+        /// Enables replacement of ASCII punctuation characters with
+        /// Unicode ligatures and smart quotes.
+        ///
         /// This includes replacing `--` with `—`, `---` with `—`, `...` with `…`,
-        /// `"quote"` with `“quote”`, and `'quote'` with `‘quote’`.  
+        /// `"quote"` with `“quote”`, and `'quote'` with `‘quote’`.
+        ///
         /// The replacement takes place during the parsing of the document.
         const ENABLE_SMART_PUNCTUATION = 1 << 5;
         /// Extension to allow headings to have ID and classes.


### PR DESCRIPTION
`ENABLE_SMART_PUNCTUATION` setting was not documented.
I added a brief description after looking at the source code in https://github.com/pulldown-cmark/pulldown-cmark/blob/1f36c334d958b6f91eeabefc405c7f86d81c300c/pulldown-cmark/src/firstpass.rs#L1120

Please, double-check if it is full and correct.