### PR TITLE
Use an explicit node for tight paragraphs

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2788,3 +2788,13 @@ the trailing space after the &gt; should be stripped
 .
 <p><a href="Wiki%3C">Link</a></p>
 ````````````````````````````````
+
+```````````````````````````````` example_wikilinks
+* <c
+  >
+.
+<ul>
+<li>&lt;c
+<blockquote></blockquote></li>
+</ul>
+````````````````````````````````

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3325,3 +3325,17 @@ fn regression_test_208() {
 
     test_markdown_html(original, expected, false, false, false, false, true);
 }
+
+#[test]
+fn regression_test_209() {
+    let original = r##"* <c
+  >
+"##;
+    let expected = r##"<ul>
+<li>&lt;c
+<blockquote></blockquote></li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, true);
+}


### PR DESCRIPTION
This cleans up a lot of hacks, because our tree didn't quite match the way commonmark actually works, and we need to avoid letting a block appear as a child of an inline.

It also fixes a bug in HTML parsing that could only be hit with tight lists.

Fixes #1002