### PR TITLE
Improve definition list docs

### DIFF
--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -725,8 +725,10 @@ bitflags::bitflags! {
         /// ```markdown
         /// title 1
         ///   : definition 1
+        ///
         /// title 2
-        ///   : definition 2
+        ///   : definition 2a
+        ///   : definition 2b
         /// ```
         const ENABLE_DEFINITION_LIST = 1 << 12;
         const ENABLE_SUPERSCRIPT = 1 << 13;


### PR DESCRIPTION
- Include a newline between definition list items in the example
  - Without the newline, `title 2` is absorbed into `definition 2`
- Demonstrate multiple definitions for a term