### PR TITLE
Correctly parse all-spaces line between refdef and paragraph

### DIFF
--- a/pulldown-cmark/build.rs
+++ b/pulldown-cmark/build.rs
@@ -86,7 +86,7 @@ fn {}_test_{i}() {{
     let original = r##"{original}"##;
     let expected = r##"{expected}"##;
 
-    test_markdown_html(original, expected, {smart_punct}, {metadata_blocks}, {old_footnotes}, {subscript}, {wikilinks});
+    test_markdown_html(original, expected, {smart_punct}, {metadata_blocks}, {old_footnotes}, {subscript}, {wikilinks}, {deflists});
 }}
 "###,
                     spec_name,
@@ -98,6 +98,7 @@ fn {}_test_{i}() {{
                     old_footnotes = testcase.old_footnotes,
                     subscript = testcase.subscript,
                     wikilinks = testcase.wikilinks,
+                    deflists = testcase.deflists,
                 ))
                 .unwrap();
 
@@ -155,6 +156,7 @@ pub struct TestCase {
     pub old_footnotes: bool,
     pub subscript: bool,
     pub wikilinks: bool,
+    pub deflists: bool,
 }
 
 #[cfg(feature = "gen-tests")]
@@ -165,17 +167,19 @@ impl<'a> Iterator for Spec<'a> {
         let spec = self.spec;
         let prefix = "```````````````````````````````` example";
 
-        let (i_start, smart_punct, metadata_blocks, old_footnotes, subscript, wikilinks) =
+        let (i_start, smart_punct, metadata_blocks, old_footnotes, subscript, wikilinks, deflists) =
             self.spec.find(prefix).and_then(|pos| {
                 let smartpunct_suffix = "_smartpunct\n";
                 let metadata_blocks_suffix = "_metadata_blocks\n";
                 let old_footnotes_suffix = "_old_footnotes\n";
                 let super_sub_suffix = "_super_sub\n";
                 let wikilinks_suffix = "_wikilinks\n";
+                let deflists_suffix = "_deflists\n";
                 if spec[(pos + prefix.len())..].starts_with(smartpunct_suffix) {
                     Some((
                         pos + prefix.len() + smartpunct_suffix.len(),
                         true,
+                        false,
                         false,
                         false,
                         false,
@@ -189,6 +193,7 @@ impl<'a> Iterator for Spec<'a> {
                         false,
                         false,
                         false,
+                        false,
                     ))
                 } else if spec[(pos + prefix.len())..].starts_with(old_footnotes_suffix) {
                     Some((
@@ -196,6 +201,7 @@ impl<'a> Iterator for Spec<'a> {
                         false,
                         false,
                         true,
+                        false,
                         false,
                         false,
                     ))
@@ -207,6 +213,7 @@ impl<'a> Iterator for Spec<'a> {
                         false,
                         true,
                         false,
+                        false,
                     ))
                 } else if spec[(pos + prefix.len())..].starts_with(wikilinks_suffix) {
                     Some((
@@ -216,9 +223,28 @@ impl<'a> Iterator for Spec<'a> {
                         false,
                         false,
                         true,
+                        false,
+                    ))
+                } else if spec[(pos + prefix.len())..].starts_with(deflists_suffix) {
+                    Some((
+                        pos + prefix.len() + deflists_suffix.len(),
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        true,
                     ))
                 } else if spec[(pos + prefix.len())..].starts_with('\n') {
-                    Some((pos + prefix.len() + 1, false, false, false, false, false))
+                    Some((
+                        pos + prefix.len() + 1,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                    ))
                 } else {
                     None
                 }
@@ -242,6 +268,7 @@ impl<'a> Iterator for Spec<'a> {
             old_footnotes,
             subscript,
             wikilinks,
+            deflists,
         };
 
         Some(test_case)

--- a/pulldown-cmark/specs/definition_lists.txt
+++ b/pulldown-cmark/specs/definition_lists.txt
@@ -673,3 +673,15 @@ level three</dt>
 <dd>l1</dd>
 </dl>
 ````````````````````````````````
+
+https://github.com/pulldown-cmark/pulldown-cmark/issues/997
+
+Definition lists combined with link refdef
+
+```````````````````````````````` example_deflists
+[a]: /url
+    
+:
+.
+<p>:</p>
+````````````````````````````````

--- a/pulldown-cmark/specs/definition_lists.txt
+++ b/pulldown-cmark/specs/definition_lists.txt
@@ -14,7 +14,7 @@ We can't do that, because we already use `~` for strikethrough.
 The list is tight if there is no blank line between
 the term and the first definition, otherwise loose.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
 :   red fruit
 
@@ -31,7 +31,7 @@ orange
 
 Loose:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
 
 :   red fruit
@@ -54,7 +54,7 @@ orange
 
 Also loose:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
 
 :   red fruit
@@ -69,7 +69,7 @@ apple
 
 Indented marker:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
   : red fruit
 
@@ -84,7 +84,7 @@ orange
 </dl>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
 
  : red fruit
@@ -107,7 +107,7 @@ orange
 
 Multiple blocks in a definition:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 *apple*
 
 :   red fruit
@@ -144,7 +144,7 @@ crisp, pleasant to taste</p>
 
 Nested lists:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 term
 
 :   1. Para one
@@ -164,7 +164,7 @@ term
 
 Multiple definitions, tight:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
 :   red fruit
 :   computer company
@@ -185,7 +185,7 @@ orange
 
 Multiple definitions, loose:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
 
 :   red fruit
@@ -217,7 +217,7 @@ orange
 
 Lazy line continuations:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
 
 :   red fruit
@@ -253,7 +253,7 @@ fruit</p>
 
 A lazy continuation may start with a `:`, if it has enough indent.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 apple
    : > computer company
      : red fruit
@@ -290,7 +290,7 @@ chili's
 
 It may not, however, lazily act as a definition in a list.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 > cherry
 > : keyboard company
 > pomegranate
@@ -308,7 +308,7 @@ pomegranate
 
 Definition terms may span multiple lines:
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 a
 b\
 c
@@ -328,7 +328,7 @@ c</dt>
 Definition list with preceding paragraph
 (<https://github.com/jgm/commonmark-hs/issues/35>):
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 Foo
 
 bar
@@ -348,7 +348,7 @@ bim
 
 Definition list followed by paragraph.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 bar
 :   baz
 
@@ -369,7 +369,7 @@ Bloze
 The total indentation for a definition list cannot exceed four.
 This means you can't have one start with four spaces.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 bar
     :baz
 
@@ -383,7 +383,7 @@ Bloze
 You can follow one with four spaces,
 because it'll "eat" the three spaces after it.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 bar
 :    baz
 
@@ -399,7 +399,7 @@ Bloze
 To use an indented code block inside of a definition,
 you need to have five spaces of indentation after the colon.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 bar
 :       baz
 
@@ -443,7 +443,7 @@ Because of the way it eats indentation after the colon, the number of
 spaces you need for indented code blocks on subsequent lines depends on
 the indentation of the earlier block.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 *orange*
 
 :   orange fruit
@@ -487,7 +487,7 @@ the indentation of the earlier block.
 
 Definition titles can't be tables.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 Test|Table
 ----|-----
 : first
@@ -498,7 +498,7 @@ Test|Table
 </table>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 first
 : second
 
@@ -519,7 +519,7 @@ Test|Table
 
 Definition titles can't be headers
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 My section
 ==========
 : first
@@ -528,7 +528,7 @@ My section
 <p>: first</p>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 first
 : second
 
@@ -544,7 +544,7 @@ My section
 <p>: fourth</p>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 ## My subsection
 : first
 .
@@ -552,7 +552,7 @@ My section
 <p>: first</p>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 first
 : second
 
@@ -570,7 +570,7 @@ first
 
 Definition list titles can't be block quotes
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 > first
 : second
 .
@@ -583,7 +583,7 @@ Definition list titles can't be block quotes
 
 Definition titles can't end with hard line breaks.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 first\
 : second
 
@@ -601,7 +601,7 @@ third
 
 Definition titles can't be HTML blocks, but inline's fine.
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 <div>first</div>
 : second
 
@@ -620,7 +620,7 @@ first
 : fourth
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 <span>first</span>
 : second
 
@@ -643,7 +643,7 @@ third
 Nested definition lists:
 (<https://github.com/pulldown-cmark/pulldown-cmark/issues/973>):
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 level one
 : l1
     level two

--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2824,3 +2824,15 @@ https://github.com/pulldown-cmark/pulldown-cmark/issues/999
 </blockquote></li>
 </ul>
 ````````````````````````````````
+
+https://github.com/pulldown-cmark/pulldown-cmark/issues/997
+
+Link refdef split from paragraph with line with spaces.
+
+```````````````````````````````` example
+[a]: /url
+    
+:
+.
+<p>:</p>
+````````````````````````````````

--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2647,7 +2647,7 @@ ISSUE #655
 
 ISSUE #949
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 * def this
   : def text def text
 .
@@ -2661,7 +2661,7 @@ ISSUE #949
 </ul>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 * def this
 
   : def text def text
@@ -2676,7 +2676,7 @@ ISSUE #949
 </ul>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 **A:**
 
 > B C
@@ -2696,7 +2696,7 @@ T U, V W</dd>
 <dd>x:.)</dd></dl></blockquote>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example_deflists
 [abc] check `foobar_raz`
  Some preamble `foobar_raz`, not `barfoo_raz`
  :D

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -421,12 +421,13 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         let mut line_start = LineStart::new(bytes);
         let tree_position = scan_containers(&self.tree, &mut line_start, self.options);
         let current_container = tree_position == self.tree.spine_len();
-        if !line_start.scan_space(4)
+        if (!line_start.scan_space(4)
             && self.scan_paragraph_interrupt(
                 &bytes[line_start.bytes_scanned()..],
                 current_container,
                 tree_position,
-            )
+            ))
+            || scan_blank_line(&bytes[line_start.bytes_scanned()..]).is_some()
         {
             None
         } else {

--- a/pulldown-cmark/tests/lib.rs
+++ b/pulldown-cmark/tests/lib.rs
@@ -14,6 +14,7 @@ pub fn test_markdown_html(
     old_footnotes: bool,
     subscript: bool,
     wikilinks: bool,
+    deflists: bool,
 ) {
     let mut s = String::new();
 
@@ -43,7 +44,9 @@ pub fn test_markdown_html(
         opts.insert(Options::ENABLE_SMART_PUNCTUATION);
     }
     opts.insert(Options::ENABLE_HEADING_ATTRIBUTES);
-    opts.insert(Options::ENABLE_DEFINITION_LIST);
+    if deflists {
+        opts.insert(Options::ENABLE_DEFINITION_LIST);
+    }
 
     let p = Parser::new_ext(input, opts);
     pulldown_cmark::html::push_html(&mut s, p);

--- a/pulldown-cmark/tests/suite/blockquotes_tags.rs
+++ b/pulldown-cmark/tests/suite/blockquotes_tags.rs
@@ -10,7 +10,7 @@ fn blockquotes_tags_test_1() {
     let expected = r##"<blockquote><p>This is a normal blockquote without tag.</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -21,7 +21,7 @@ fn blockquotes_tags_test_2() {
     let expected = r##"<blockquote class="markdown-alert-note"><p>Note blockquote</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn blockquotes_tags_test_3() {
     let expected = r##"<blockquote class="markdown-alert-tip"><p>Tip blockquote</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn blockquotes_tags_test_4() {
     let expected = r##"<blockquote class="markdown-alert-important"><p>Important blockquote</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn blockquotes_tags_test_5() {
     let expected = r##"<blockquote class="markdown-alert-warning"><p>Warning blockquote</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn blockquotes_tags_test_6() {
     let expected = r##"<blockquote class="markdown-alert-caution"><p>Caution blockquote</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn blockquotes_tags_test_7() {
     let expected = r##"<blockquote class="markdown-alert-caution"></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn blockquotes_tags_test_8() {
 Line 2.</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn blockquotes_tags_test_9() {
 Line 2.</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn blockquotes_tags_test_10() {
     let expected = r##"<blockquote class="markdown-alert-caution"><p>Line 1.</p><blockquote class="markdown-alert-tip"><p>Line 2.</p></blockquote></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn blockquotes_tags_test_11() {
     let expected = r##"<blockquote class="markdown-alert-caution"><p>Line 1.</p></blockquote><blockquote class="markdown-alert-tip"><p>Line 2.</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn blockquotes_tags_test_12() {
 Line 2.</p></blockquote></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn blockquotes_tags_test_13() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn blockquotes_tags_test_14() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -189,7 +189,7 @@ fn blockquotes_tags_test_15() {
 </li></ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -216,7 +216,7 @@ sink ships
 </li></ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -237,7 +237,7 @@ fn blockquotes_tags_test_17() {
 </li></ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -251,5 +251,5 @@ This should be a normal block quote.</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/definition_lists.rs
+++ b/pulldown-cmark/tests/suite/definition_lists.rs
@@ -300,7 +300,7 @@ chili's
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -320,7 +320,7 @@ pomegranate
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -621,7 +621,7 @@ fn definition_lists_test_26() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -720,6 +720,18 @@ level three</dt>
 <dt>level one</dt>
 <dd>l1</dd>
 </dl>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, false, true);
+}
+
+#[test]
+fn definition_lists_test_31() {
+    let original = r##"[a]: /url
+    
+:
+"##;
+    let expected = r##"<p>:</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, true);

--- a/pulldown-cmark/tests/suite/definition_lists.rs
+++ b/pulldown-cmark/tests/suite/definition_lists.rs
@@ -19,7 +19,7 @@ orange
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -44,7 +44,7 @@ orange
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn definition_lists_test_3() {
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -80,7 +80,7 @@ orange
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -105,7 +105,7 @@ orange
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -144,7 +144,7 @@ crisp, pleasant to taste</p>
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn definition_lists_test_7() {
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -189,7 +189,7 @@ orange
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -223,7 +223,7 @@ orange
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -261,7 +261,7 @@ fruit</p>
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -341,7 +341,7 @@ c</dt>
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -363,7 +363,7 @@ bim
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -385,7 +385,7 @@ Bloze
 <p>Bloze</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -400,7 +400,7 @@ Bloze
 <p>Bloze</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -417,7 +417,7 @@ Bloze
 <p>Bloze</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -460,7 +460,7 @@ bar
 :   baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -506,7 +506,7 @@ fn definition_lists_test_19() {
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -521,7 +521,7 @@ fn definition_lists_test_20() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -543,7 +543,7 @@ Test|Table
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -556,7 +556,7 @@ fn definition_lists_test_22() {
 <p>: first</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -576,7 +576,7 @@ My section
 <p>: fourth</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -588,7 +588,7 @@ fn definition_lists_test_24() {
 <p>: first</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -607,7 +607,7 @@ fn definition_lists_test_25() {
 <p>: fourth</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -640,7 +640,7 @@ third
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -663,7 +663,7 @@ first
 : fourth
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -687,7 +687,7 @@ third
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -722,5 +722,5 @@ level three</dt>
 </dl>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }

--- a/pulldown-cmark/tests/suite/footnotes.rs
+++ b/pulldown-cmark/tests/suite/footnotes.rs
@@ -15,7 +15,7 @@ fn footnotes_test_1() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -34,7 +34,7 @@ Yes it goes on and on my friends.<sup class="footnote-reference"><a href="#lambc
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn footnotes_test_3() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn footnotes_test_4() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn footnotes_test_5() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -138,7 +138,7 @@ d</p>
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -161,7 +161,7 @@ I had largely given over my inquiries into what Professor Angell called the "Cth
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -180,7 +180,7 @@ If a woodchuck could chuck wood.
 <h1>Forms of entertainment that aren't childish</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn footnotes_test_9() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -233,7 +233,7 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
 <p>As such, we can guarantee that the non-childish forms of entertainment are probably more entertaining to adults, since, having had a whole childhood doing the childish ones, the non-childish ones are merely the ones that haven't gotten boring yet.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn footnotes_test_11() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -293,7 +293,7 @@ fn footnotes_test_12() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -312,7 +312,7 @@ fn footnotes_test_13() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -336,7 +336,7 @@ An unordered list before the footnotes:
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -393,7 +393,7 @@ Songs that simply loop are a popular way to annoy people. [^examples3]
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -431,7 +431,7 @@ test suite into pulldown-cmark should be fine.</p>
 <p>[otherlink<sup class="footnote-reference"><a href="#c">1</a></sup>]: https://github.com/github/cmark-gfm/blob/1e230827a584ebc9938c3eadc5059c55ef3c9abf/test/extensions.txt#L702</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -456,7 +456,7 @@ fn main() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -470,7 +470,7 @@ fn footnotes_test_18() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -494,7 +494,7 @@ fn footnotes_test_19() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -556,7 +556,7 @@ Second <sup class="footnote-reference"><a href="#2">2</a></sup> test</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -568,7 +568,7 @@ fn footnotes_test_21() {
     let expected = r##"<p>Test <a href="https://rust-lang.org">^</a> link</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -608,7 +608,7 @@ second</a>
 fourth]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -623,7 +623,7 @@ fn footnotes_test_23() {
 </a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -644,7 +644,7 @@ footnote [^quux]</p>
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -663,7 +663,7 @@ fn footnotes_test_25() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -682,5 +682,5 @@ fn footnotes_test_26() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/gfm_strikethrough.rs
+++ b/pulldown-cmark/tests/suite/gfm_strikethrough.rs
@@ -10,7 +10,7 @@ fn gfm_strikethrough_test_1() {
     let expected = r##"<p><del>Hi</del> Hello, <del>there</del> world!</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -23,7 +23,7 @@ new paragraph~~.
 <p>new paragraph~~.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -33,5 +33,5 @@ fn gfm_strikethrough_test_3() {
     let expected = r##"<p>This will ~~~not~~~ strike.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/gfm_table.rs
+++ b/pulldown-cmark/tests/suite/gfm_table.rs
@@ -25,7 +25,7 @@ fn gfm_table_test_1() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -50,7 +50,7 @@ bar | baz
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn gfm_table_test_3() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -106,7 +106,7 @@ fn gfm_table_test_4() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -139,7 +139,7 @@ bar
 <p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -153,7 +153,7 @@ fn gfm_table_test_6() {
 | bar |</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -183,7 +183,7 @@ fn gfm_table_test_7() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn gfm_table_test_8() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -229,5 +229,5 @@ fn gfm_table_test_9() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/gfm_tasklist.rs
+++ b/pulldown-cmark/tests/suite/gfm_tasklist.rs
@@ -16,7 +16,7 @@ bar</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -41,5 +41,5 @@ bim</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/heading_attrs.rs
+++ b/pulldown-cmark/tests/suite/heading_attrs.rs
@@ -20,7 +20,7 @@ multiple! {.myclass1 myattr #myh3 otherattr=value .myclass2}
 <h2 id="myh3" class="myclass1 myclass2" myattr="" otherattr="value">multiple!</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn heading_attrs_test_2() {
 <h3 id="myh3" class="myclass1 myclass2" myattr="" otherattr="value">multiple!</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn heading_attrs_test_3() {
 <h4>non-attribute-block {#id4}</h4>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn heading_attrs_test_4() {
 <h2 id="myid2">tabs</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -77,7 +77,7 @@ nextline
 <p>nextline</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -99,7 +99,7 @@ nextline {.class}
 <p>](https://example.com/) {#myid3}</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -114,7 +114,7 @@ cont
 </h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn heading_attrs_test_8() {
 }</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -145,7 +145,7 @@ fn heading_attrs_test_9() {
 <h2 id="id2">recommended style with spaces</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn heading_attrs_test_10() {
 <h3 class="myclass">H3</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn heading_attrs_test_11() {
 <h2 class="class1#id2.class2">H2</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -183,7 +183,7 @@ fn heading_attrs_test_12() {
 <h2>H2 {#id2</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn heading_attrs_test_13() {
 <h2>H2 #id2}</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -207,7 +207,7 @@ fn heading_attrs_test_14() {
 <h2>H2 {#id2} <!-- hello --></h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -225,7 +225,7 @@ fn heading_attrs_test_15() {
 <h5 id="id5"><a href="uri">text</a></h5>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -235,7 +235,7 @@ fn heading_attrs_test_16() {
     let expected = r##"<h1 id="last">H1</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn heading_attrs_test_17() {
     let expected = r##"<h1 class="z a zz">H1</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -255,7 +255,7 @@ fn heading_attrs_test_18() {
     let expected = r##"<h1 class="a a a">H1</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -267,7 +267,7 @@ fn heading_attrs_test_19() {
 <h2 id="m" class="z a">H2</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -279,7 +279,7 @@ fn heading_attrs_test_20() {
 <h2 id="myid" class="myclass" unknown="" this#is.ignored="" attr="value">H2</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -289,7 +289,7 @@ fn heading_attrs_test_21() {
     let expected = r##"<h1 myattr="value" other_attr="">Header</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -299,7 +299,7 @@ fn heading_attrs_test_22() {
     let expected = r##"<h4 id="id" class="class1" myattr="" other_attr="false">Header</h4>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -311,7 +311,7 @@ fn heading_attrs_test_23() {
 <h2 class="bar">H2 {.foo</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn heading_attrs_test_24() {
     let expected = r##"<h1>H1 {.foo}bar}</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -331,7 +331,7 @@ fn heading_attrs_test_25() {
     let expected = r##"<h1>H1 {<i>foo</i>}</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -341,7 +341,7 @@ fn heading_attrs_test_26() {
     let expected = r##"<h1>H1 {.foo}</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -354,7 +354,7 @@ fn heading_attrs_test_27() {
 .bar}</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -368,7 +368,7 @@ fn heading_attrs_test_28() {
 <h2>H2 {}</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -378,7 +378,7 @@ fn heading_attrs_test_29() {
     let expected = r##"<h2>H2 {}</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -396,7 +396,7 @@ newline can be used for setext heading {
 }</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -410,7 +410,7 @@ fn heading_attrs_test_31() {
 <h3>stray backslash at the end is preserved \</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -428,7 +428,7 @@ stray backslash at the end is preserved \
 <h2>stray backslash at the end is preserved \</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -442,7 +442,7 @@ fn heading_attrs_test_33() {
 <h3 id="foo**bar**baz">H3</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -461,7 +461,7 @@ H2-2 {#foo**bar**baz}
 <h2 id="foo**bar**baz">H2-2</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -475,7 +475,7 @@ fn heading_attrs_test_35() {
 <h3 class="a&quot;b&#39;c&amp;d">H3</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -487,7 +487,7 @@ fn heading_attrs_test_36() {
 <h2>H2</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -499,7 +499,7 @@ fn heading_attrs_test_37() {
 <h1 class="foo bar">H1</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -518,7 +518,7 @@ fn heading_attrs_test_38() {
 <p>#{}</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -545,7 +545,7 @@ fn heading_attrs_test_39() {
 <h2>{}</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -565,7 +565,7 @@ fn heading_attrs_test_40() {
 <h3 id="vt">vertical tab</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -580,7 +580,7 @@ fn heading_attrs_test_41() {
 <h1 id="vt.myclass">vertical tab (U+000B)</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -592,5 +592,5 @@ fn heading_attrs_test_42() {
 <h2 id="ideographic-space　.myclass">IDEOGRAPHIC SPACE (U+3000)</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/math.rs
+++ b/pulldown-cmark/tests/suite/math.rs
@@ -15,7 +15,7 @@ $\sum_{k=1}^n a_k b_k$: Mathematical expression at head of line
 <p><code>\</code> may follow just after the first <code>$</code>: <span class="math math-inline">\{1, 2, 3\}</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -28,7 +28,7 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \
 <p><span class="math math-display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -41,7 +41,7 @@ $$$$
 <p><span class="math math-display"></span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -57,7 +57,7 @@ $$x$$$$$$y$$
 <p><span class="math math-display">x</span><span class="math math-display"></span>y$$</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -82,7 +82,7 @@ $&alpha;$
 <p><span class="math math-inline">&amp;alpha;</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -95,7 +95,7 @@ Dollar at end of line$
 <p>Dollar at end of line$</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -112,7 +112,7 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
 \left( \sum_{k=1}^n b_k^2 \right)</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -126,7 +126,7 @@ hard break
 either</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -139,7 +139,7 @@ $$y = \$ x$$
 <p><span class="math math-display">y = \$ x</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -152,7 +152,7 @@ $$ $ $$
 <p>$$ $ $$</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -162,7 +162,7 @@ fn math_test_11() {
     let expected = r##"<p>alpha$<span class="math math-inline">beta</span>gamma$$delta</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -190,7 +190,7 @@ they should not allow inlines to do that $$2 +
 <span class="math math-inline">*</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -200,7 +200,7 @@ fn math_test_13() {
     let expected = r##"<p>these are math texts: foo<span class="math math-inline">y=x</span>bar and <span class="math math-inline">y=x</span>bar and foo<span class="math math-inline">y=x</span> bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -216,7 +216,7 @@ braces: ($x=y$) [$x=y$] {$x=y$}
 <p>braces: (<span class="math math-inline">x=y</span>) [<span class="math math-inline">x=y</span>] {<span class="math math-inline">x=y</span>}</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn math_test_15() {
     let expected = r##"<p><span class="math math-inline">x=y</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -245,7 +245,7 @@ $$a$$$$b$$
 <p><span class="math math-display">a</span><span class="math math-display">b</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -264,7 +264,7 @@ $$ Display `first $$ then` code
 <p><code>Code $$ first</code> then $$ display</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -288,7 +288,7 @@ $$ x + y
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -311,7 +311,7 @@ not</p>
 $$</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -334,7 +334,7 @@ math$</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -354,7 +354,7 @@ And this is inline math:
 <span class="math math-inline">\text{Hello $x$ there!}</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -379,7 +379,7 @@ Math environment contains y: $x {$ $ } $y$
 <p>Math environment contains y: $x {$ $ } <span class="math math-inline">y</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -412,7 +412,7 @@ and expected to be as short as possible:</p>
 <p><span class="math math-display"></span>\text{first $$ second}$$</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -434,7 +434,7 @@ $}$] $$
 <p>$}$] $$</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -444,7 +444,7 @@ fn math_test_25() {
     let expected = r##"<p><span class="math math-inline">x</span> <span class="math math-inline">`y`</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -486,7 +486,7 @@ b
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -500,7 +500,7 @@ fn math_test_27() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -523,7 +523,7 @@ A = 5
 </details>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -536,7 +536,7 @@ $$a<b$$
 <p><span class="math math-display">a&lt;b</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -551,7 +551,7 @@ fn math_test_30() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -563,7 +563,7 @@ fn math_test_31() {
 </p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -579,7 +579,7 @@ fn math_test_32() {
 <p>1<span class="math math-inline">x</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -595,7 +595,7 @@ _$a$ equals $b$_
 <p><strong><span class="math math-inline">a</span> equals <span class="math math-inline">b</span></strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -618,7 +618,7 @@ a
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -628,7 +628,7 @@ fn math_test_35() {
     let expected = r##"<p><span class="math math-inline">\{a\,b\}</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -644,7 +644,7 @@ ${a}_b c_{d}$
 <p><span class="math math-inline">{a}_b c_{d}</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -656,7 +656,7 @@ $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 <span class="math math-display"> x = {-b \pm \sqrt{b^2-4ac} \over 2a} </span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -666,7 +666,7 @@ fn math_test_38() {
     let expected = r##"<p><span class="math math-inline">x = \$</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -676,7 +676,7 @@ fn math_test_39() {
     let expected = r##"<p><em>Equation <span class="math math-inline">\Omega(69)</span> in italic text</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -700,7 +700,7 @@ fn math_test_40() {
 </p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -716,7 +716,7 @@ fn math_test_41() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -732,7 +732,7 @@ fn math_test_42() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -770,7 +770,7 @@ fn math_test_43() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -790,7 +790,7 @@ improperly <span class="math math-inline">}{</span> nested
 But this still isn't, because the braces are still counted: $}{$</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -819,7 +819,7 @@ another improperly nested example
 }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}</span></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -853,7 +853,7 @@ fn math_test_46() {
 {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{</span> 255 brace pairs and one unclosed brace</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -915,5 +915,5 @@ fn math_test_47() {
 }}}}}}}}}}}}}}}{$ 255 close braces and one open brace</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/metadata_blocks.rs
+++ b/pulldown-cmark/tests/suite/metadata_blocks.rs
@@ -12,7 +12,7 @@ another_field: 0
 "##;
     let expected = r##""##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -26,7 +26,7 @@ another_field: 0
 another_field: 0</p>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn metadata_blocks_test_3() {
 <hr>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -54,7 +54,7 @@ another_field: 0
 another_field: 0</h2>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -70,7 +70,7 @@ another_field: 0
 another_field: 0</h2>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -85,7 +85,7 @@ another_field: 0
     let expected = r##"<p>My paragraph here.</p>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -105,7 +105,7 @@ another_field: 0
 another_field: 0</h2>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -126,7 +126,7 @@ another_field: 0
 ---a</p>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -138,7 +138,7 @@ another_field: 0
 "##;
     let expected = r##""##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -150,7 +150,7 @@ another_field: 0
 "##;
     let expected = r##""##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -165,7 +165,7 @@ Things
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -177,5 +177,5 @@ fn metadata_blocks_test_12() {
 "##;
     let expected = r##""##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/old_footnotes.rs
+++ b/pulldown-cmark/tests/suite/old_footnotes.rs
@@ -15,7 +15,7 @@ fn old_footnotes_test_1() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, true, false, false);
+    test_markdown_html(original, expected, false, false, true, false, false, false);
 }
 
 #[test]
@@ -34,7 +34,7 @@ Yes it goes on and on my friends.<sup class="footnote-reference"><a href="#lambc
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, true, false, false);
+    test_markdown_html(original, expected, false, false, true, false, false, false);
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn old_footnotes_test_3() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, true, false, false);
+    test_markdown_html(original, expected, false, false, true, false, false, false);
 }
 
 #[test]
@@ -71,7 +71,7 @@ I had largely given over my inquiries into what Professor Angell called the "Cth
 <p>I had largely given over my inquiries into what Professor Angell called the "Cthulhu Cult", and was visiting a learned friend in Paterson, New Jersey; the curator of a local museum and a mineralogist of note. Examining one day the reserve specimens roughly set on the storage shelves in a rear room of the museum, my eye was caught by an odd picture in one of the old papers spread beneath the stones. It was the Sydney Bulletin I have mentioned, for my friend had wide affiliations in all conceivable foreign parts; and the picture was a half-tone cut of a hideous stone image almost identical with that which Legrasse had found in the swamp.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, true, false, false);
+    test_markdown_html(original, expected, false, false, true, false, false, false);
 }
 
 #[test]
@@ -90,7 +90,7 @@ If a woodchuck could chuck wood.
 <h1>Forms of entertainment that aren't childish</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, true, false, false);
+    test_markdown_html(original, expected, false, false, true, false, false, false);
 }
 
 #[test]
@@ -110,7 +110,7 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
 <p>As such, we can guarantee that the non-childish forms of entertainment are probably more entertaining to adults, since, having had a whole childhood doing the childish ones, the non-childish ones are merely the ones that haven't gotten boring yet.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, true, false, false);
+    test_markdown_html(original, expected, false, false, true, false, false, false);
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn old_footnotes_test_7() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, true, false, false);
+    test_markdown_html(original, expected, false, false, true, false, false, false);
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn old_footnotes_test_8() {
 <div class="footnote-definition" id="1"><sup class="footnote-definition-label">2</sup><p>Common for people practicing music.</p></div>
 "##;
 
-    test_markdown_html(original, expected, false, false, true, false, false);
+    test_markdown_html(original, expected, false, false, true, false, false, false);
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn old_footnotes_test_9() {
     let expected = r##"<p>[Reference to footnotes A<sup class="footnote-reference"><a href="#1">1</a></sup>, B<sup class="footnote-reference"><a href="#2">2</a></sup> and C<sup class="footnote-reference"><a href="#3">3</a></sup>.</p><div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup><p>Footnote A.</p></div><div class="footnote-definition" id="2"><sup class="footnote-definition-label">2</sup><p>Footnote B.</p></div><div class="footnote-definition" id="3"><sup class="footnote-definition-label">3</sup><p>Footnote C.</p></div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -192,7 +192,7 @@ fn old_footnotes_test_10() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -211,5 +211,5 @@ fn old_footnotes_test_11() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -16,7 +16,7 @@ This is a test of the details element.
 </details>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn regression_test_2() {
     let expected = r##"<p>see the <a href="https://medium.com/@jlouis666/quickcheck-advice-c357efb4e7e6">many</a> <a href="http://www.quviq.com/products/erlang-quickcheck/">articles</a> <a href="https://wiki.haskell.org/Introduction_to_QuickCheck1">on</a> <a href="https://hackage.haskell.org/package/QuickCheck">QuickCheck</a>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn regression_test_3() {
 <a href="https://docs.rs/debug_stub_derive/0.3.0/"><img src="https://docs.rs/debug_stub_derive/badge.svg?version=0.3.0" alt="debug-stub-derive on docs.rs" /></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn regression_test_4() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn regression_test_5() {
     let expected = r##"<p>foo§<strong>(bar)</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn regression_test_6() {
     let expected = r##"<p><a href="https://example.com">https://example.com</a> hello</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn regression_test_7() {
 <!-- foo -->
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn regression_test_8() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -144,7 +144,7 @@ i8
     let expected = r##"<p><a href="../../../std/primitive.i8.html"><code>i8</code></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -156,7 +156,7 @@ fn regression_test_10() {
     let expected = r##"<p><a href="/url" title="title\*">a</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -168,7 +168,7 @@ fn regression_test_11() {
     let expected = r##"<p><a href="/url" title="title)">a</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -181,7 +181,7 @@ fn regression_test_12() {
 <p>[a]: /url (title))</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -194,7 +194,7 @@ b <?php but this is ?>
 <p>b <?php but this is ?></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -205,7 +205,7 @@ foo
     let expected = r##"<p>foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -215,7 +215,7 @@ fn regression_test_15() {
     let expected = r##"<p>`foo`</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -227,7 +227,7 @@ bar
 bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -240,7 +240,7 @@ fn regression_test_17() {
 <p>1) bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -262,7 +262,7 @@ fn regression_test_18() {
 <p>1)2)3)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn regression_test_19() {
     let expected = r##"<p>[](&lt;&lt;&gt;)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -282,7 +282,7 @@ fn regression_test_20() {
     let expected = r##"<p>`<code>foo``bar</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -292,7 +292,7 @@ fn regression_test_21() {
     let expected = r##"<p>\<code>foo</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -304,7 +304,7 @@ YOLO
     let expected = r##"<p>YOLO</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -320,7 +320,7 @@ A | B
 foo | bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -334,7 +334,7 @@ foo|bar
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -348,7 +348,7 @@ foo|bar
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -358,7 +358,7 @@ fn regression_test_26() {
     let expected = r##"<p><a href="url"><foo></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -368,7 +368,7 @@ fn regression_test_27() {
     let expected = r##"<p><a href="url"><foo>bar</foo></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -378,7 +378,7 @@ fn regression_test_28() {
     let expected = r##"<p><img src="http://example.com/logo.png" alt="http://example.com" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -388,7 +388,7 @@ fn regression_test_29() {
     let expected = r##"<p><a href="url"><a href="http://one">http://one</a> <a href="http://two">http://two</a></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -403,7 +403,7 @@ some text
 <p>some text</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -424,7 +424,7 @@ fn regression_test_31() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -439,7 +439,7 @@ x</p>
 <p>]: f</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -449,7 +449,7 @@ fn regression_test_33() {
     let expected = r##"<p>[foo]:</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -464,7 +464,7 @@ fn regression_test_34() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -479,7 +479,7 @@ yolo | swag
 <p>yolo | swag</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -489,7 +489,7 @@ fn regression_test_36() {
     let expected = r##"<foo bar>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -501,7 +501,7 @@ fn regression_test_37() {
  "hi"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -514,7 +514,7 @@ __a__
 <p><strong>a</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -527,7 +527,7 @@ fn regression_test_39() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -537,7 +537,7 @@ fn regression_test_40() {
     let expected = r##"<p><code>\|</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -550,7 +550,7 @@ Paragraph 2
 <p>Paragraph 2</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -560,7 +560,7 @@ fn regression_test_42() {
     let expected = r##"<p>[<a href="https://www.google.com/">link text</a>]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -572,7 +572,7 @@ fn regression_test_43() {
     let expected = r##"<table><thead><tr><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>[a](&lt;</td><td>url&gt;)</td></tr></tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -586,7 +586,7 @@ fn regression_test_44() {
 <p>")</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -599,7 +599,7 @@ fn regression_test_45() {
 <p>)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -612,7 +612,7 @@ fn regression_test_46() {
 <p>")</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -622,7 +622,7 @@ fn regression_test_47() {
     let expected = r##"<p>&lt;http:// &gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -632,7 +632,7 @@ fn regression_test_48() {
     let expected = r##"<p>&lt;http://&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -651,7 +651,7 @@ fn regression_test_49() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -670,7 +670,7 @@ fn regression_test_50() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -680,7 +680,7 @@ fn regression_test_51() {
     let expected = r##"<p><sup>*hi</sup>_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -690,7 +690,7 @@ fn regression_test_52() {
     let expected = r##"<p>email: <a href="mailto:john@example.com">john@example.com</a>_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -704,7 +704,7 @@ bar">link</a></p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -719,7 +719,7 @@ fn regression_test_54() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -735,7 +735,7 @@ bar</a></p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -753,7 +753,7 @@ fn regression_test_56() {
 <p><a href="/foo">a b c</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -770,7 +770,7 @@ fn regression_test_57() {
 <p>[a b] [a &gt; b]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -783,7 +783,7 @@ package`]
     let expected = r##"<p><a href="https://example.com"><code>cargo package</code></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -798,7 +798,7 @@ fn regression_test_59() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -811,7 +811,7 @@ fn regression_test_60() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -827,7 +827,7 @@ the size of <code>usize</code> and have the same alignment.</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -851,7 +851,7 @@ An unordered list before the footnotes:
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -869,7 +869,7 @@ fn regression_test_63() {
 <h1>assimp-rs <a href="https://crates.io/crates/assimp"><img src="http://meritbadge.herokuapp.com/assimp" alt="" /></a></h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -914,7 +914,7 @@ fn regression_test_64() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -924,7 +924,7 @@ fn regression_test_65() {
     let expected = r##"<p>&lt;foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -942,7 +942,7 @@ lo"></p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -953,7 +953,7 @@ fn regression_test_67() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -975,7 +975,7 @@ a
 2. a</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -991,7 +991,7 @@ fn regression_test_69() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1010,7 +1010,7 @@ bar</p></li>
 <p>baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1029,7 +1029,7 @@ fn regression_test_71() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1041,7 +1041,7 @@ fn regression_test_72() {
     let expected = r##"<p>[<code>]</code>]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1051,7 +1051,7 @@ fn regression_test_73() {
     let expected = r##"<p><del>foo</del>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1061,7 +1061,7 @@ fn regression_test_74() {
     let expected = r##"<p>foo<del>bar</del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1071,7 +1071,7 @@ fn regression_test_75() {
     let expected = r##"<p><em><del><strong>emphasis strike strong</strong></del></em> <del><em><strong>strike emphasis strong</strong></em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1081,7 +1081,7 @@ fn regression_test_76() {
     let expected = r##"<p><em><del><strong>emphasis strike strong</strong></del></em> <del><em><strong><code>strike emphasis strong code</code></strong></em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1091,7 +1091,7 @@ fn regression_test_77() {
     let expected = r##"<p><em><del><code>emphasis strike code</code></del></em> <del><em><strong>strike emphasis strong</strong></em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1101,7 +1101,7 @@ fn regression_test_78() {
     let expected = r##"<p><em><del><code>emphasis strike code</code></del></em> <del><em><strong><code>strike emphasis strong code</code></strong></em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1111,7 +1111,7 @@ fn regression_test_79() {
     let expected = r##"<p><strong><del><em>strong strike emphasis</em></del></strong> <del><em><strong>strike emphasis strong</strong></em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1121,7 +1121,7 @@ fn regression_test_80() {
     let expected = r##"<p><strong><del><em>strong strike emphasis</em></del></strong> <del><em><strong><code>strike emphasis strong code</code></strong></em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1131,7 +1131,7 @@ fn regression_test_81() {
     let expected = r##"<p><strong><del><code>strong strike code</code></del></strong> <del><em><strong>strike emphasis strong</strong></em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1141,7 +1141,7 @@ fn regression_test_82() {
     let expected = r##"<p><strong><del><code>strong strike code</code></del></strong> <del><em><strong><code>strike emphasis strong code</code></strong></em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1234,7 +1234,7 @@ fn regression_test_83() {
 | baz | alef |</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1244,7 +1244,7 @@ fn regression_test_84() {
     let expected = r##"<h3></h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1254,7 +1254,7 @@ fn regression_test_85() {
     let expected = r##"<h3></h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1264,7 +1264,7 @@ fn regression_test_86() {
     let expected = r##"<!doctype html>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1326,7 +1326,7 @@ fn regression_test_87() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1339,7 +1339,7 @@ b
 <p>b</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1353,7 +1353,7 @@ fn regression_test_89() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1367,7 +1367,7 @@ fn regression_test_90() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1379,7 +1379,7 @@ fn regression_test_91() {
 <h1>b</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1390,7 +1390,7 @@ fn regression_test_92() {
     let expected = r##"<h1>a\</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1403,7 +1403,7 @@ fn regression_test_93() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1415,7 +1415,7 @@ fn regression_test_94() {
 <blockquote></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1427,7 +1427,7 @@ fn regression_test_95() {
 >
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1439,7 +1439,7 @@ fn regression_test_96() {
 <blockquote><p>quote</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1451,7 +1451,7 @@ fn regression_test_97() {
 > not quote
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1463,7 +1463,7 @@ fn regression_test_98() {
 <blockquote><p>quote</p></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1475,7 +1475,7 @@ fn regression_test_99() {
 >not quote
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1494,7 +1494,7 @@ fn regression_test_100() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1504,7 +1504,7 @@ fn regression_test_101() {
     let expected = r##"<p>*<em><em>R]</em>-</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1514,7 +1514,7 @@ fn regression_test_102() {
     let expected = r##"<p><strong><em><em>foo</em>bar</em>baz</strong>**</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1528,7 +1528,7 @@ fn regression_test_103() {
 %</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1542,7 +1542,7 @@ fn regression_test_104() {
 %</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1552,7 +1552,7 @@ fn regression_test_105() {
     let expected = r##"<p>&lt;@1&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1566,7 +1566,7 @@ Things
     let expected = r##"<p>Things</p>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -1581,7 +1581,7 @@ Things
     let expected = r##"<p>Things</p>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -1595,7 +1595,7 @@ Things
     let expected = r##"<p>Things</p>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -1619,7 +1619,7 @@ fn regression_test_109() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1634,7 +1634,7 @@ fn regression_test_110() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1644,7 +1644,7 @@ fn regression_test_111() {
     let expected = r##"<p>j*<em><em>5</em>=</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1710,7 +1710,7 @@ Table
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1723,7 +1723,7 @@ fn regression_test_113() {
 <p>[x]: (</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1745,7 +1745,7 @@ an unmatched asterisk.</p>
 <em>{</em>{</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1755,7 +1755,7 @@ fn regression_test_115() {
     let expected = r##"<p>*<em>a.*.<em><em>a</em>.</em></em>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1774,7 +1774,7 @@ _*xx-_-
 <p><em>*xx-</em>-</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1803,7 +1803,7 @@ fn regression_test_117() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1832,7 +1832,7 @@ fn regression_test_118() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1845,7 +1845,7 @@ fn regression_test_119() {
 <p>]: https://rust-lang.org</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1878,7 +1878,7 @@ fn regression_test_120() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1921,7 +1921,7 @@ The second hyphen should parse the same way in both samples.
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1936,7 +1936,7 @@ https://rust-lang.org
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1949,7 +1949,7 @@ Second try]: https://rust-lang.org
 <p>Second try]: https://rust-lang.org</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1972,7 +1972,7 @@ fn regression_test_124() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1984,7 +1984,7 @@ bar \
 <p>bar \</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1998,7 +1998,7 @@ fn regression_test_126() {
 <p>[third try]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2018,7 +2018,7 @@ bar
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2040,7 +2040,7 @@ fn regression_test_128() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2051,7 +2051,7 @@ fn regression_test_129() {
     let expected = r##"<p>-</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2068,7 +2068,7 @@ foo)
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2085,7 +2085,7 @@ fn regression_test_131() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2104,7 +2104,7 @@ fn regression_test_132() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2125,7 +2125,7 @@ fn regression_test_133() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2136,7 +2136,7 @@ fn regression_test_134() {
     let expected = r##"<p>- baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2154,7 +2154,7 @@ GFM footnotes can interrupt link defs if they have three spaces, but not four.
 <p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2171,7 +2171,7 @@ Setext heading can interrupt link def if it has three spaces, but not four.
 <p>Setext heading can interrupt link def if it has three spaces, but not four.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2191,7 +2191,7 @@ List can interrupt the paragraph at the start of a link definition if it starts 
 <p>List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2210,7 +2210,7 @@ second]
 <p>second]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2228,7 +2228,7 @@ second]
 second</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2245,7 +2245,7 @@ fn regression_test_140() {
 <p><a href="https://example.com">first</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2262,7 +2262,7 @@ fn regression_test_141() {
 ">first</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2281,7 +2281,7 @@ fn regression_test_142() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2300,7 +2300,7 @@ fn regression_test_143() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2319,7 +2319,7 @@ fn regression_test_144() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2336,7 +2336,7 @@ fn regression_test_145() {
 ">first</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2355,7 +2355,7 @@ fn regression_test_146() {
 <p><a href="https://example.com">first</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2366,7 +2366,7 @@ fn regression_test_147() {
     let expected = r##"<p>'<a href="https://example.com">foo</a>'bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2382,7 +2382,7 @@ fn regression_test_148() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2398,7 +2398,7 @@ a]: https://example.com
     let expected = r##"<p><a href="https://example.com">a</a> <a href="https://example.com">b</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2419,7 +2419,7 @@ fn regression_test_150() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2441,7 +2441,7 @@ baz*</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2463,7 +2463,7 @@ baz`</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2485,7 +2485,7 @@ baz](https://example.com)</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2500,7 +2500,7 @@ part of the title'
 part of the title">mylink</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2517,7 +2517,7 @@ starts in column <em>three</em>.</li>
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2531,7 +2531,7 @@ fn regression_test_156() {
 <p>This is not in the list at all. It's a paragraph after it.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2543,7 +2543,7 @@ fn regression_test_157() {
     let expected = r##"<p><code>\!\&amp;quot;\#\$\%\&amp; \!\&amp;quot;\#\$\%\&amp; \!\&amp;quot;\#\$\%\&amp;</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2555,7 +2555,7 @@ fn regression_test_158() {
 -|- *</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2568,7 +2568,7 @@ fn regression_test_159() {
 <p>Another paragraph whose spaces must be removed.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2583,7 +2583,7 @@ fn regression_test_160() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2598,7 +2598,7 @@ fn regression_test_161() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2608,7 +2608,7 @@ fn regression_test_162() {
     let expected = r##"<p>&amp;#00000000; &amp;#x0000000;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2618,7 +2618,7 @@ fn regression_test_163() {
     let expected = r##"<p>�</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2634,7 +2634,7 @@ t_</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2650,7 +2650,7 @@ N*</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2661,7 +2661,7 @@ fn regression_test_166() {
     let expected = r##" <foo>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2672,7 +2672,7 @@ fn regression_test_167() {
     let expected = r##"<foo>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2683,7 +2683,7 @@ fn regression_test_168() {
     let expected = r##"   <foo>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2699,7 +2699,7 @@ fn regression_test_169() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2718,7 +2718,7 @@ fn regression_test_170() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2734,7 +2734,7 @@ fn regression_test_171() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2750,7 +2750,7 @@ fn regression_test_172() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2766,7 +2766,7 @@ fn regression_test_173() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2782,7 +2782,7 @@ fn regression_test_174() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2800,7 +2800,7 @@ fn regression_test_175() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2813,7 +2813,7 @@ fn regression_test_176() {
 <p>[link]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2826,7 +2826,7 @@ fn regression_test_177() {
 <p>[link]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2838,7 +2838,7 @@ fn regression_test_178() {
     let expected = r##"<p><a href="test" title="()">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2851,7 +2851,7 @@ fn regression_test_179() {
 <p>[link]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2863,7 +2863,7 @@ fn regression_test_180() {
     let expected = r##"<p><a href="test" title="&quot;">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2876,7 +2876,7 @@ fn regression_test_181() {
 <p>[link]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2888,7 +2888,7 @@ fn regression_test_182() {
     let expected = r##"<p><a href="test" title="&#39;">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2906,7 +2906,7 @@ fn regression_test_183() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2920,7 +2920,7 @@ test2
 <p>test2</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2936,7 +2936,7 @@ test2</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2953,7 +2953,7 @@ fn regression_test_186() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2973,7 +2973,7 @@ fn regression_test_187() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2986,7 +2986,7 @@ fn regression_test_188() {
 <p>&lt;!p&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2998,7 +2998,7 @@ fn regression_test_189() {
     let expected = r##"<p><a href="((()))">linky</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3014,7 +3014,7 @@ junk</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3026,7 +3026,7 @@ fn regression_test_191() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3037,7 +3037,7 @@ fn regression_test_192() {
     let expected = r##"<pre><code></code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3051,7 +3051,7 @@ fn regression_test_193() {
 text          ">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3069,7 +3069,7 @@ _**
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3084,7 +3084,7 @@ fn regression_test_195() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3097,7 +3097,7 @@ fn regression_test_196() {
 <h2>--</h2>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -3109,7 +3109,7 @@ fn regression_test_197() {
 [40](https://rust.org/something%3A((((((((((((((((((((((((((((((((((((((((())))))))))))))))))))))))))))))))))))))))))</p>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -3124,7 +3124,7 @@ fn regression_test_198() {
 <h2>\</h2>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -3140,7 +3140,7 @@ bar
 <p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, true, false, false, false);
+    test_markdown_html(original, expected, false, true, false, false, false, false);
 }
 
 #[test]
@@ -3151,7 +3151,7 @@ fn regression_test_200() {
     let expected = r##"<p><code> </code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3169,7 +3169,7 @@ fn regression_test_201() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -3188,7 +3188,7 @@ fn regression_test_202() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -3212,7 +3212,7 @@ T U, V W</dd>
 <dd>x:.)</dd></dl></blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -3234,7 +3234,7 @@ Some preamble <code>foobar_raz</code>, not <code>barfoo_raz</code></dt>
 <p>&gt; Something is wrong!</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, true);
 }
 
 #[test]
@@ -3251,7 +3251,7 @@ stuff](https://example.com)</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3300,7 +3300,7 @@ fn regression_test_206() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3313,7 +3313,7 @@ fn regression_test_207() {
 &gt;</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3323,7 +3323,7 @@ fn regression_test_208() {
     let expected = r##"<p><a href="Wiki%3C">Link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -3337,7 +3337,7 @@ fn regression_test_209() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -3365,5 +3365,5 @@ fn regression_test_210() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3367,3 +3367,15 @@ fn regression_test_210() {
 
     test_markdown_html(original, expected, false, false, false, false, true, false);
 }
+
+#[test]
+fn regression_test_211() {
+    let original = r##"[a]: /url
+    
+:
+"##;
+    let expected = r##"<p>:</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, false, false);
+}

--- a/pulldown-cmark/tests/suite/smart_punct.rs
+++ b/pulldown-cmark/tests/suite/smart_punct.rs
@@ -12,7 +12,7 @@ fn smart_punct_test_1() {
 “‘Shelob’ is my name.”</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -22,7 +22,7 @@ fn smart_punct_test_2() {
     let expected = r##"<p>‘A’, ‘B’, and ‘C’ are letters.</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -34,7 +34,7 @@ So is 'pine.'
 So is ‘pine.’</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn smart_punct_test_4() {
     let expected = r##"<p>‘He said, “I want to go.”’</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn smart_punct_test_5() {
     let expected = r##"<p>Were you alive in the 70’s?</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn smart_punct_test_6() {
     let expected = r##"<p>Here is some quoted ‘<code>code</code>’ and a “<a href="url">quoted link</a>”.</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn smart_punct_test_7() {
     let expected = r##"<p>’tis the season to be ‘jolly’</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -84,7 +84,7 @@ fn smart_punct_test_8() {
     let expected = r##"<p>‘We’ll use Jane’s boat and John’s truck,’ Jenna said.</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn smart_punct_test_9() {
 <p>“Second paragraph by same speaker, in fiction.”</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn smart_punct_test_10() {
     let expected = r##"<p>[a]’s b’</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -121,7 +121,7 @@ This isn't either.
 5'8"</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -139,7 +139,7 @@ en – en
 2–3</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -167,7 +167,7 @@ nine———
 thirteen———––.</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -177,7 +177,7 @@ fn smart_punct_test_14() {
     let expected = r##"<p>Escaped hyphens: -- ---.</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -187,7 +187,7 @@ fn smart_punct_test_15() {
     let expected = r##"<p>Ellipses…and…and….</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }
 
 #[test]
@@ -197,5 +197,5 @@ fn smart_punct_test_16() {
     let expected = r##"<p>No ellipses...</p>
 "##;
 
-    test_markdown_html(original, expected, true, false, false, false, false);
+    test_markdown_html(original, expected, true, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/spec.rs
+++ b/pulldown-cmark/tests/suite/spec.rs
@@ -11,7 +11,7 @@ fn spec_test_1() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -22,7 +22,7 @@ fn spec_test_2() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -35,7 +35,7 @@ fn spec_test_3() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn spec_test_4() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn spec_test_5() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn spec_test_6() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn spec_test_7() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -111,7 +111,7 @@ bar
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn spec_test_9() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn spec_test_10() {
     let expected = r##"<h1>Foo</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -153,7 +153,7 @@ fn spec_test_11() {
     let expected = r##"<hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -163,7 +163,7 @@ fn spec_test_12() {
     let expected = r##"<p>!"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn spec_test_13() {
     let expected = r##"<p>\	\A\a\ \3\φ\«</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -199,7 +199,7 @@ fn spec_test_14() {
 &amp;ouml; not a character entity</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -209,7 +209,7 @@ fn spec_test_15() {
     let expected = r##"<p>\<em>emphasis</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -221,7 +221,7 @@ bar
 bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn spec_test_17() {
     let expected = r##"<p><code>\[\`</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -242,7 +242,7 @@ fn spec_test_18() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -255,7 +255,7 @@ fn spec_test_19() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -265,7 +265,7 @@ fn spec_test_20() {
     let expected = r##"<p><a href="https://example.com?find=%5C*">https://example.com?find=\*</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -275,7 +275,7 @@ fn spec_test_21() {
     let expected = r##"<a href="/bar\/)">
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -285,7 +285,7 @@ fn spec_test_22() {
     let expected = r##"<p><a href="/bar*" title="ti*tle">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -297,7 +297,7 @@ fn spec_test_23() {
     let expected = r##"<p><a href="/bar*" title="ti*tle">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -310,7 +310,7 @@ foo
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -324,7 +324,7 @@ fn spec_test_25() {
 ∲ ≧̸</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -334,7 +334,7 @@ fn spec_test_26() {
     let expected = r##"<p># Ӓ Ϡ �</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -344,7 +344,7 @@ fn spec_test_27() {
     let expected = r##"<p>" ആ ಫ</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -360,7 +360,7 @@ fn spec_test_28() {
 &amp;ThisIsNotDefined; &amp;hi?;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -370,7 +370,7 @@ fn spec_test_29() {
     let expected = r##"<p>&amp;copy</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -380,7 +380,7 @@ fn spec_test_30() {
     let expected = r##"<p>&amp;MadeUpEntity;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -390,7 +390,7 @@ fn spec_test_31() {
     let expected = r##"<a href="&ouml;&ouml;.html">
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -400,7 +400,7 @@ fn spec_test_32() {
     let expected = r##"<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -412,7 +412,7 @@ fn spec_test_33() {
     let expected = r##"<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -425,7 +425,7 @@ foo
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -435,7 +435,7 @@ fn spec_test_35() {
     let expected = r##"<p><code>f&amp;ouml;&amp;ouml;</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -446,7 +446,7 @@ fn spec_test_36() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -458,7 +458,7 @@ fn spec_test_37() {
 <em>foo</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -473,7 +473,7 @@ fn spec_test_38() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -485,7 +485,7 @@ fn spec_test_39() {
 bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -495,7 +495,7 @@ fn spec_test_40() {
     let expected = r##"<p>	foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -505,7 +505,7 @@ fn spec_test_41() {
     let expected = r##"<p>[a](url "tit")</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -519,7 +519,7 @@ fn spec_test_42() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -533,7 +533,7 @@ ___
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -543,7 +543,7 @@ fn spec_test_44() {
     let expected = r##"<p>+++</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -553,7 +553,7 @@ fn spec_test_45() {
     let expected = r##"<p>===</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -567,7 +567,7 @@ __
 __</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -581,7 +581,7 @@ fn spec_test_47() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -592,7 +592,7 @@ fn spec_test_48() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -604,7 +604,7 @@ fn spec_test_49() {
 ***</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -614,7 +614,7 @@ fn spec_test_50() {
     let expected = r##"<hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -624,7 +624,7 @@ fn spec_test_51() {
     let expected = r##"<hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -634,7 +634,7 @@ fn spec_test_52() {
     let expected = r##"<hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -644,7 +644,7 @@ fn spec_test_53() {
     let expected = r##"<hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -654,7 +654,7 @@ fn spec_test_54() {
     let expected = r##"<hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -670,7 +670,7 @@ a------
 <p>---a---</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -680,7 +680,7 @@ fn spec_test_56() {
     let expected = r##"<p><em>-</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -698,7 +698,7 @@ fn spec_test_57() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -712,7 +712,7 @@ bar
 <p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -725,7 +725,7 @@ bar
 <p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -743,7 +743,7 @@ fn spec_test_60() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -759,7 +759,7 @@ fn spec_test_61() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -779,7 +779,7 @@ fn spec_test_62() {
 <h6>foo</h6>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -789,7 +789,7 @@ fn spec_test_63() {
     let expected = r##"<p>####### foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -802,7 +802,7 @@ fn spec_test_64() {
 <p>#hashtag</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -812,7 +812,7 @@ fn spec_test_65() {
     let expected = r##"<p>## foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -822,7 +822,7 @@ fn spec_test_66() {
     let expected = r##"<h1>foo <em>bar</em> *baz*</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -832,7 +832,7 @@ fn spec_test_67() {
     let expected = r##"<h1>foo</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -846,7 +846,7 @@ fn spec_test_68() {
 <h1>foo</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -857,7 +857,7 @@ fn spec_test_69() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -869,7 +869,7 @@ fn spec_test_70() {
 # bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -881,7 +881,7 @@ fn spec_test_71() {
 <h3>bar</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -893,7 +893,7 @@ fn spec_test_72() {
 <h5>foo</h5>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -903,7 +903,7 @@ fn spec_test_73() {
     let expected = r##"<h3>foo</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -913,7 +913,7 @@ fn spec_test_74() {
     let expected = r##"<h3>foo ### b</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -923,7 +923,7 @@ fn spec_test_75() {
     let expected = r##"<h1>foo#</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -937,7 +937,7 @@ fn spec_test_76() {
 <h1>foo #</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -951,7 +951,7 @@ fn spec_test_77() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -965,7 +965,7 @@ Bar foo
 <p>Bar foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -979,7 +979,7 @@ fn spec_test_79() {
 <h3></h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -994,7 +994,7 @@ Foo *bar*
 <h2>Foo <em>bar</em></h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1007,7 +1007,7 @@ baz*
 baz</em></h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1020,7 +1020,7 @@ baz*
 baz</em></h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1035,7 +1035,7 @@ Foo
 <h1>Foo</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1054,7 +1054,7 @@ fn spec_test_84() {
 <h1>Foo</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1073,7 +1073,7 @@ Foo
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1084,7 +1084,7 @@ fn spec_test_86() {
     let expected = r##"<h2>Foo</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1096,7 +1096,7 @@ fn spec_test_87() {
 ---</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1113,7 +1113,7 @@ Foo
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1124,7 +1124,7 @@ fn spec_test_89() {
     let expected = r##"<h2>Foo</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1135,7 +1135,7 @@ fn spec_test_90() {
     let expected = r##"<h2>Foo\</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1154,7 +1154,7 @@ of dashes"/>
 <p>of dashes"/&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1168,7 +1168,7 @@ fn spec_test_92() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1184,7 +1184,7 @@ bar
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1198,7 +1198,7 @@ fn spec_test_94() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1211,7 +1211,7 @@ Bar
 Bar</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1229,7 +1229,7 @@ Baz
 <p>Baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1240,7 +1240,7 @@ fn spec_test_97() {
     let expected = r##"<p>====</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1252,7 +1252,7 @@ fn spec_test_98() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1266,7 +1266,7 @@ fn spec_test_99() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1279,7 +1279,7 @@ fn spec_test_100() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1293,7 +1293,7 @@ fn spec_test_101() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1304,7 +1304,7 @@ fn spec_test_102() {
     let expected = r##"<h2>&gt; foo</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1320,7 +1320,7 @@ baz
 <p>baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1338,7 +1338,7 @@ bar</p>
 <p>baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1354,7 +1354,7 @@ bar</p>
 <p>baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1370,7 +1370,7 @@ bar
 baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1383,7 +1383,7 @@ fn spec_test_107() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1400,7 +1400,7 @@ fn spec_test_108() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1419,7 +1419,7 @@ fn spec_test_109() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1436,7 +1436,7 @@ fn spec_test_110() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1459,7 +1459,7 @@ chunk3
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1474,7 +1474,7 @@ fn spec_test_112() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1487,7 +1487,7 @@ fn spec_test_113() {
 bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1500,7 +1500,7 @@ bar
 <p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1521,7 +1521,7 @@ Heading
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1534,7 +1534,7 @@ bar
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1549,7 +1549,7 @@ fn spec_test_117() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1560,7 +1560,7 @@ fn spec_test_118() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1575,7 +1575,7 @@ fn spec_test_119() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1590,7 +1590,7 @@ fn spec_test_120() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1602,7 +1602,7 @@ foo
     let expected = r##"<p><code>foo</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1617,7 +1617,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1632,7 +1632,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1647,7 +1647,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1662,7 +1662,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1672,7 +1672,7 @@ fn spec_test_126() {
     let expected = r##"<pre><code></code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1688,7 +1688,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1705,7 +1705,7 @@ bbb
 <p>bbb</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1720,7 +1720,7 @@ fn spec_test_129() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1731,7 +1731,7 @@ fn spec_test_130() {
     let expected = r##"<pre><code></code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1746,7 +1746,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1763,7 +1763,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1780,7 +1780,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1795,7 +1795,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1808,7 +1808,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1821,7 +1821,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1835,7 +1835,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1847,7 +1847,7 @@ aaa
 aaa</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1861,7 +1861,7 @@ aaa
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1878,7 +1878,7 @@ baz
 <p>baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1896,7 +1896,7 @@ bar
 <h1>baz</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1913,7 +1913,7 @@ end
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1930,7 +1930,7 @@ end
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1941,7 +1941,7 @@ fn spec_test_144() {
     let expected = r##"<pre><code class="language-;"></code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1953,7 +1953,7 @@ foo
 foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1966,7 +1966,7 @@ foo
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -1979,7 +1979,7 @@ fn spec_test_147() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2000,7 +2000,7 @@ _world_.
 </td></tr></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2025,7 +2025,7 @@ okay.
 <p>okay.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2039,7 +2039,7 @@ fn spec_test_150() {
          <foo><a>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2051,7 +2051,7 @@ fn spec_test_151() {
 *foo*
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2067,7 +2067,7 @@ fn spec_test_152() {
 </DIV>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2081,7 +2081,7 @@ fn spec_test_153() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2095,7 +2095,7 @@ fn spec_test_154() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2110,7 +2110,7 @@ fn spec_test_155() {
 <p><em>bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2122,7 +2122,7 @@ fn spec_test_156() {
 *hi*
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2134,7 +2134,7 @@ foo
 foo
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2146,7 +2146,7 @@ fn spec_test_158() {
 *foo*
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2156,7 +2156,7 @@ fn spec_test_159() {
     let expected = r##"<div><a href="bar">*foo*</a></div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2170,7 +2170,7 @@ foo
 </td></tr></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2186,7 +2186,7 @@ int x = 33;
 ```
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2200,7 +2200,7 @@ fn spec_test_162() {
 </a>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2214,7 +2214,7 @@ fn spec_test_163() {
 </Warning>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2228,7 +2228,7 @@ fn spec_test_164() {
 </i>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2240,7 +2240,7 @@ fn spec_test_165() {
 *bar*
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2254,7 +2254,7 @@ fn spec_test_166() {
 </del>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2270,7 +2270,7 @@ fn spec_test_167() {
 </del>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2280,7 +2280,7 @@ fn spec_test_168() {
     let expected = r##"<p><del><em>foo</em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2302,7 +2302,7 @@ main = print $ parseTags tags
 <p>okay</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2322,7 +2322,7 @@ document.getElementById("demo").innerHTML = "Hello JavaScript!";
 <p>okay</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2344,7 +2344,7 @@ _bar_
 </textarea>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2366,7 +2366,7 @@ p {color:blue;}
 <p>okay</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2382,7 +2382,7 @@ foo
 foo
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2399,7 +2399,7 @@ foo
 <p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2415,7 +2415,7 @@ fn spec_test_175() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2427,7 +2427,7 @@ fn spec_test_176() {
 <p><em>foo</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2439,7 +2439,7 @@ fn spec_test_177() {
 <p><em>baz</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2453,7 +2453,7 @@ foo
 </script>1. *bar*
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2471,7 +2471,7 @@ bar
 <p>okay</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2491,7 +2491,7 @@ okay
 <p>okay</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2501,7 +2501,7 @@ fn spec_test_181() {
     let expected = r##"<!DOCTYPE html>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2535,7 +2535,7 @@ function matchwo(a,b)
 <p>okay</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2549,7 +2549,7 @@ fn spec_test_183() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2563,7 +2563,7 @@ fn spec_test_184() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2579,7 +2579,7 @@ bar
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2595,7 +2595,7 @@ bar
 *foo*
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2609,7 +2609,7 @@ baz
 baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2625,7 +2625,7 @@ fn spec_test_188() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2639,7 +2639,7 @@ fn spec_test_189() {
 </div>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2665,7 +2665,7 @@ Hi
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2692,7 +2692,7 @@ fn spec_test_191() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2704,7 +2704,7 @@ fn spec_test_192() {
     let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2718,7 +2718,7 @@ fn spec_test_193() {
     let expected = r##"<p><a href="/url" title="the title">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2730,7 +2730,7 @@ fn spec_test_194() {
     let expected = r##"<p><a href="my_(url)" title="title (with parens)">Foo*bar]</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2744,7 +2744,7 @@ fn spec_test_195() {
     let expected = r##"<p><a href="my%20url" title="title">Foo bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2764,7 +2764,7 @@ line2
 ">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2780,7 +2780,7 @@ with blank line'
 <p>[foo]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2793,7 +2793,7 @@ fn spec_test_198() {
     let expected = r##"<p><a href="/url">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2806,7 +2806,7 @@ fn spec_test_199() {
 <p>[foo]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2818,7 +2818,7 @@ fn spec_test_200() {
     let expected = r##"<p><a href="">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2831,7 +2831,7 @@ fn spec_test_201() {
 <p>[foo]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2843,7 +2843,7 @@ fn spec_test_202() {
     let expected = r##"<p><a href="/url%5Cbar*baz" title="foo&quot;bar\baz">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2855,7 +2855,7 @@ fn spec_test_203() {
     let expected = r##"<p><a href="url">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2868,7 +2868,7 @@ fn spec_test_204() {
     let expected = r##"<p><a href="first">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2880,7 +2880,7 @@ fn spec_test_205() {
     let expected = r##"<p><a href="/url">Foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2892,7 +2892,7 @@ fn spec_test_206() {
     let expected = r##"<p><a href="/%CF%86%CE%BF%CF%85">αγω</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2901,7 +2901,7 @@ fn spec_test_207() {
 "##;
     let expected = r##""##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2914,7 +2914,7 @@ bar
     let expected = r##"<p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2924,7 +2924,7 @@ fn spec_test_209() {
     let expected = r##"<p>[foo]: /url "title" ok</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2935,7 +2935,7 @@ fn spec_test_210() {
     let expected = r##"<p>"title" ok</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2949,7 +2949,7 @@ fn spec_test_211() {
 <p>[foo]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2965,7 +2965,7 @@ fn spec_test_212() {
 <p>[foo]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2980,7 +2980,7 @@ fn spec_test_213() {
 <p>[bar]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -2995,7 +2995,7 @@ fn spec_test_214() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3009,7 +3009,7 @@ bar
 <p><a href="/url">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3022,7 +3022,7 @@ fn spec_test_216() {
 <a href="/url">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3041,7 +3041,7 @@ fn spec_test_217() {
 <a href="/baz-url">baz</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3055,7 +3055,7 @@ fn spec_test_218() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3068,7 +3068,7 @@ bbb
 <p>bbb</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3085,7 +3085,7 @@ bbb</p>
 ddd</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3099,7 +3099,7 @@ bbb
 <p>bbb</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3111,7 +3111,7 @@ fn spec_test_222() {
 bbb</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3125,7 +3125,7 @@ bbb
 ccc</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3137,7 +3137,7 @@ bbb
 bbb</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3150,7 +3150,7 @@ bbb
 <p>bbb</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3162,7 +3162,7 @@ bbb
 bbb</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3180,7 +3180,7 @@ aaa
 <h1>aaa</h1>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3196,7 +3196,7 @@ baz</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3212,7 +3212,7 @@ baz</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3228,7 +3228,7 @@ baz</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3243,7 +3243,7 @@ fn spec_test_231() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3259,7 +3259,7 @@ baz</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3275,7 +3275,7 @@ foo</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3289,7 +3289,7 @@ fn spec_test_234() {
 <hr />
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3307,7 +3307,7 @@ fn spec_test_235() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3323,7 +3323,7 @@ fn spec_test_236() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3339,7 +3339,7 @@ foo
 <pre><code></code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3353,7 +3353,7 @@ fn spec_test_238() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3364,7 +3364,7 @@ fn spec_test_239() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3377,7 +3377,7 @@ fn spec_test_240() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3391,7 +3391,7 @@ fn spec_test_241() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3408,7 +3408,7 @@ fn spec_test_242() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3422,7 +3422,7 @@ bar</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3437,7 +3437,7 @@ fn spec_test_244() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3451,7 +3451,7 @@ fn spec_test_245() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3469,7 +3469,7 @@ fn spec_test_246() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3483,7 +3483,7 @@ baz</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3498,7 +3498,7 @@ baz
 <p>baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3513,7 +3513,7 @@ baz
 <p>baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3531,7 +3531,7 @@ bar</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3551,7 +3551,7 @@ baz</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3569,7 +3569,7 @@ fn spec_test_252() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3590,7 +3590,7 @@ with two lines.</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3615,7 +3615,7 @@ with two lines.</p>
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3630,7 +3630,7 @@ fn spec_test_255() {
 <p>two</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3647,7 +3647,7 @@ fn spec_test_256() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3663,7 +3663,7 @@ fn spec_test_257() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3680,7 +3680,7 @@ fn spec_test_258() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3701,7 +3701,7 @@ fn spec_test_259() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3720,7 +3720,7 @@ fn spec_test_260() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3733,7 +3733,7 @@ fn spec_test_261() {
 <p>2.two</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3751,7 +3751,7 @@ fn spec_test_262() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3779,7 +3779,7 @@ fn spec_test_263() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3803,7 +3803,7 @@ baz
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3815,7 +3815,7 @@ fn spec_test_265() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3825,7 +3825,7 @@ fn spec_test_266() {
     let expected = r##"<p>1234567890. not ok</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3837,7 +3837,7 @@ fn spec_test_267() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3849,7 +3849,7 @@ fn spec_test_268() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3859,7 +3859,7 @@ fn spec_test_269() {
     let expected = r##"<p>-1. not ok</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3877,7 +3877,7 @@ fn spec_test_270() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3895,7 +3895,7 @@ fn spec_test_271() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3913,7 +3913,7 @@ paragraph
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3935,7 +3935,7 @@ fn spec_test_273() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3957,7 +3957,7 @@ fn spec_test_274() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3970,7 +3970,7 @@ bar
 <p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -3985,7 +3985,7 @@ fn spec_test_276() {
 <p>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4002,7 +4002,7 @@ fn spec_test_277() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4029,7 +4029,7 @@ fn spec_test_278() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4042,7 +4042,7 @@ fn spec_test_279() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4057,7 +4057,7 @@ fn spec_test_280() {
 <p>foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4073,7 +4073,7 @@ fn spec_test_281() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4089,7 +4089,7 @@ fn spec_test_282() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4105,7 +4105,7 @@ fn spec_test_283() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4117,7 +4117,7 @@ fn spec_test_284() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4134,7 +4134,7 @@ foo
 1.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4159,7 +4159,7 @@ with two lines.</p>
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4184,7 +4184,7 @@ with two lines.</p>
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4209,7 +4209,7 @@ with two lines.</p>
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4230,7 +4230,7 @@ fn spec_test_289() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4255,7 +4255,7 @@ with two lines.</p>
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4269,7 +4269,7 @@ with two lines.</li>
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4289,7 +4289,7 @@ continued here.</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4309,7 +4309,7 @@ continued here.</p>
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4336,7 +4336,7 @@ fn spec_test_294() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4354,7 +4354,7 @@ fn spec_test_295() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4371,7 +4371,7 @@ fn spec_test_296() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4387,7 +4387,7 @@ fn spec_test_297() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4403,7 +4403,7 @@ fn spec_test_298() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4423,7 +4423,7 @@ fn spec_test_299() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4443,7 +4443,7 @@ baz</li>
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4461,7 +4461,7 @@ fn spec_test_301() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4479,7 +4479,7 @@ fn spec_test_302() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4495,7 +4495,7 @@ fn spec_test_303() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4507,7 +4507,7 @@ fn spec_test_304() {
 14.  The number of doors is 6.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4521,7 +4521,7 @@ fn spec_test_305() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4546,7 +4546,7 @@ fn spec_test_306() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4574,7 +4574,7 @@ fn spec_test_307() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4598,7 +4598,7 @@ fn spec_test_308() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4627,7 +4627,7 @@ fn spec_test_309() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4651,7 +4651,7 @@ fn spec_test_310() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4675,7 +4675,7 @@ fn spec_test_311() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4695,7 +4695,7 @@ fn spec_test_312() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4718,7 +4718,7 @@ fn spec_test_313() {
 </code></pre>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4741,7 +4741,7 @@ fn spec_test_314() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4762,7 +4762,7 @@ fn spec_test_315() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4787,7 +4787,7 @@ fn spec_test_316() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4811,7 +4811,7 @@ fn spec_test_317() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4836,7 +4836,7 @@ fn spec_test_318() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4860,7 +4860,7 @@ fn spec_test_319() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4880,7 +4880,7 @@ fn spec_test_320() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4904,7 +4904,7 @@ fn spec_test_321() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4916,7 +4916,7 @@ fn spec_test_322() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4933,7 +4933,7 @@ fn spec_test_323() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4953,7 +4953,7 @@ fn spec_test_324() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -4974,7 +4974,7 @@ fn spec_test_325() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5005,7 +5005,7 @@ fn spec_test_326() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5015,7 +5015,7 @@ fn spec_test_327() {
     let expected = r##"<p><code>hi</code>lo`</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5025,7 +5025,7 @@ fn spec_test_328() {
     let expected = r##"<p><code>foo</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5035,7 +5035,7 @@ fn spec_test_329() {
     let expected = r##"<p><code>foo ` bar</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5045,7 +5045,7 @@ fn spec_test_330() {
     let expected = r##"<p><code>``</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5055,7 +5055,7 @@ fn spec_test_331() {
     let expected = r##"<p><code> `` </code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5065,7 +5065,7 @@ fn spec_test_332() {
     let expected = r##"<p><code> a</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5075,7 +5075,7 @@ fn spec_test_333() {
     let expected = r##"<p><code> b </code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5087,7 +5087,7 @@ fn spec_test_334() {
 <code>  </code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5101,7 +5101,7 @@ baz
     let expected = r##"<p><code>foo bar   baz</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5113,7 +5113,7 @@ foo
     let expected = r##"<p><code>foo </code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5124,7 +5124,7 @@ baz`
     let expected = r##"<p><code>foo   bar  baz</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5134,7 +5134,7 @@ fn spec_test_338() {
     let expected = r##"<p><code>foo\</code>bar`</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5144,7 +5144,7 @@ fn spec_test_339() {
     let expected = r##"<p><code>foo`bar</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5154,7 +5154,7 @@ fn spec_test_340() {
     let expected = r##"<p><code>foo `` bar</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5164,7 +5164,7 @@ fn spec_test_341() {
     let expected = r##"<p>*foo<code>*</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5174,7 +5174,7 @@ fn spec_test_342() {
     let expected = r##"<p>[not a <code>link](/foo</code>)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5184,7 +5184,7 @@ fn spec_test_343() {
     let expected = r##"<p><code>&lt;a href="</code>"&gt;`</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5194,7 +5194,7 @@ fn spec_test_344() {
     let expected = r##"<p><a href="`">`</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5204,7 +5204,7 @@ fn spec_test_345() {
     let expected = r##"<p><code>&lt;https://foo.bar.</code>baz&gt;`</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5214,7 +5214,7 @@ fn spec_test_346() {
     let expected = r##"<p><a href="https://foo.bar.%60baz">https://foo.bar.`baz</a>`</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5224,7 +5224,7 @@ fn spec_test_347() {
     let expected = r##"<p>```foo``</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5234,7 +5234,7 @@ fn spec_test_348() {
     let expected = r##"<p>`foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5244,7 +5244,7 @@ fn spec_test_349() {
     let expected = r##"<p>`foo<code>bar</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5254,7 +5254,7 @@ fn spec_test_350() {
     let expected = r##"<p><em>foo bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5264,7 +5264,7 @@ fn spec_test_351() {
     let expected = r##"<p>a * foo bar*</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5274,7 +5274,7 @@ fn spec_test_352() {
     let expected = r##"<p>a*"foo"*</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5284,7 +5284,7 @@ fn spec_test_353() {
     let expected = r##"<p>* a *</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5300,7 +5300,7 @@ fn spec_test_354() {
 <p>*€*charlie.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5310,7 +5310,7 @@ fn spec_test_355() {
     let expected = r##"<p>foo<em>bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5320,7 +5320,7 @@ fn spec_test_356() {
     let expected = r##"<p>5<em>6</em>78</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5330,7 +5330,7 @@ fn spec_test_357() {
     let expected = r##"<p><em>foo bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5340,7 +5340,7 @@ fn spec_test_358() {
     let expected = r##"<p>_ foo bar_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5350,7 +5350,7 @@ fn spec_test_359() {
     let expected = r##"<p>a_"foo"_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5360,7 +5360,7 @@ fn spec_test_360() {
     let expected = r##"<p>foo_bar_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5370,7 +5370,7 @@ fn spec_test_361() {
     let expected = r##"<p>5_6_78</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5380,7 +5380,7 @@ fn spec_test_362() {
     let expected = r##"<p>пристаням_стремятся_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5390,7 +5390,7 @@ fn spec_test_363() {
     let expected = r##"<p>aa_"bb"_cc</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5400,7 +5400,7 @@ fn spec_test_364() {
     let expected = r##"<p>foo-<em>(bar)</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5410,7 +5410,7 @@ fn spec_test_365() {
     let expected = r##"<p>_foo*</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5420,7 +5420,7 @@ fn spec_test_366() {
     let expected = r##"<p>*foo bar *</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5432,7 +5432,7 @@ fn spec_test_367() {
 *</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5442,7 +5442,7 @@ fn spec_test_368() {
     let expected = r##"<p>*(*foo)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5452,7 +5452,7 @@ fn spec_test_369() {
     let expected = r##"<p><em>(<em>foo</em>)</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5462,7 +5462,7 @@ fn spec_test_370() {
     let expected = r##"<p><em>foo</em>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5472,7 +5472,7 @@ fn spec_test_371() {
     let expected = r##"<p>_foo bar _</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5482,7 +5482,7 @@ fn spec_test_372() {
     let expected = r##"<p>_(_foo)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5492,7 +5492,7 @@ fn spec_test_373() {
     let expected = r##"<p><em>(<em>foo</em>)</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5502,7 +5502,7 @@ fn spec_test_374() {
     let expected = r##"<p>_foo_bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5512,7 +5512,7 @@ fn spec_test_375() {
     let expected = r##"<p>_пристаням_стремятся</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5522,7 +5522,7 @@ fn spec_test_376() {
     let expected = r##"<p><em>foo_bar_baz</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5532,7 +5532,7 @@ fn spec_test_377() {
     let expected = r##"<p><em>(bar)</em>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5542,7 +5542,7 @@ fn spec_test_378() {
     let expected = r##"<p><strong>foo bar</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5552,7 +5552,7 @@ fn spec_test_379() {
     let expected = r##"<p>** foo bar**</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5562,7 +5562,7 @@ fn spec_test_380() {
     let expected = r##"<p>a**"foo"**</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5572,7 +5572,7 @@ fn spec_test_381() {
     let expected = r##"<p>foo<strong>bar</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5582,7 +5582,7 @@ fn spec_test_382() {
     let expected = r##"<p><strong>foo bar</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5592,7 +5592,7 @@ fn spec_test_383() {
     let expected = r##"<p>__ foo bar__</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5604,7 +5604,7 @@ foo bar__
 foo bar__</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5614,7 +5614,7 @@ fn spec_test_385() {
     let expected = r##"<p>a__"foo"__</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5624,7 +5624,7 @@ fn spec_test_386() {
     let expected = r##"<p>foo__bar__</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5634,7 +5634,7 @@ fn spec_test_387() {
     let expected = r##"<p>5__6__78</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5644,7 +5644,7 @@ fn spec_test_388() {
     let expected = r##"<p>пристаням__стремятся__</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5654,7 +5654,7 @@ fn spec_test_389() {
     let expected = r##"<p><strong>foo, <strong>bar</strong>, baz</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5664,7 +5664,7 @@ fn spec_test_390() {
     let expected = r##"<p>foo-<strong>(bar)</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5674,7 +5674,7 @@ fn spec_test_391() {
     let expected = r##"<p>**foo bar **</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5684,7 +5684,7 @@ fn spec_test_392() {
     let expected = r##"<p>**(**foo)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5694,7 +5694,7 @@ fn spec_test_393() {
     let expected = r##"<p><em>(<strong>foo</strong>)</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5706,7 +5706,7 @@ fn spec_test_394() {
 <em>Asclepias physocarpa</em>)</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5716,7 +5716,7 @@ fn spec_test_395() {
     let expected = r##"<p><strong>foo "<em>bar</em>" foo</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5726,7 +5726,7 @@ fn spec_test_396() {
     let expected = r##"<p><strong>foo</strong>bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5736,7 +5736,7 @@ fn spec_test_397() {
     let expected = r##"<p>__foo bar __</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5746,7 +5746,7 @@ fn spec_test_398() {
     let expected = r##"<p>__(__foo)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5756,7 +5756,7 @@ fn spec_test_399() {
     let expected = r##"<p><em>(<strong>foo</strong>)</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5766,7 +5766,7 @@ fn spec_test_400() {
     let expected = r##"<p>__foo__bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5776,7 +5776,7 @@ fn spec_test_401() {
     let expected = r##"<p>__пристаням__стремятся</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5786,7 +5786,7 @@ fn spec_test_402() {
     let expected = r##"<p><strong>foo__bar__baz</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5796,7 +5796,7 @@ fn spec_test_403() {
     let expected = r##"<p><strong>(bar)</strong>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5806,7 +5806,7 @@ fn spec_test_404() {
     let expected = r##"<p><em>foo <a href="/url">bar</a></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5818,7 +5818,7 @@ bar*
 bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5828,7 +5828,7 @@ fn spec_test_406() {
     let expected = r##"<p><em>foo <strong>bar</strong> baz</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5838,7 +5838,7 @@ fn spec_test_407() {
     let expected = r##"<p><em>foo <em>bar</em> baz</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5848,7 +5848,7 @@ fn spec_test_408() {
     let expected = r##"<p><em><em>foo</em> bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5858,7 +5858,7 @@ fn spec_test_409() {
     let expected = r##"<p><em>foo <em>bar</em></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5868,7 +5868,7 @@ fn spec_test_410() {
     let expected = r##"<p><em>foo <strong>bar</strong> baz</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5878,7 +5878,7 @@ fn spec_test_411() {
     let expected = r##"<p><em>foo<strong>bar</strong>baz</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5888,7 +5888,7 @@ fn spec_test_412() {
     let expected = r##"<p><em>foo**bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5898,7 +5898,7 @@ fn spec_test_413() {
     let expected = r##"<p><em><strong>foo</strong> bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5908,7 +5908,7 @@ fn spec_test_414() {
     let expected = r##"<p><em>foo <strong>bar</strong></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5918,7 +5918,7 @@ fn spec_test_415() {
     let expected = r##"<p><em>foo<strong>bar</strong></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5928,7 +5928,7 @@ fn spec_test_416() {
     let expected = r##"<p>foo<em><strong>bar</strong></em>baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5938,7 +5938,7 @@ fn spec_test_417() {
     let expected = r##"<p>foo<strong><strong><strong>bar</strong></strong></strong>***baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5948,7 +5948,7 @@ fn spec_test_418() {
     let expected = r##"<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5958,7 +5958,7 @@ fn spec_test_419() {
     let expected = r##"<p><em>foo <a href="/url"><em>bar</em></a></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5968,7 +5968,7 @@ fn spec_test_420() {
     let expected = r##"<p>** is not an empty emphasis</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5978,7 +5978,7 @@ fn spec_test_421() {
     let expected = r##"<p>**** is not an empty strong emphasis</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -5988,7 +5988,7 @@ fn spec_test_422() {
     let expected = r##"<p><strong>foo <a href="/url">bar</a></strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6000,7 +6000,7 @@ bar**
 bar</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6010,7 +6010,7 @@ fn spec_test_424() {
     let expected = r##"<p><strong>foo <em>bar</em> baz</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6020,7 +6020,7 @@ fn spec_test_425() {
     let expected = r##"<p><strong>foo <strong>bar</strong> baz</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6030,7 +6030,7 @@ fn spec_test_426() {
     let expected = r##"<p><strong><strong>foo</strong> bar</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6040,7 +6040,7 @@ fn spec_test_427() {
     let expected = r##"<p><strong>foo <strong>bar</strong></strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6050,7 +6050,7 @@ fn spec_test_428() {
     let expected = r##"<p><strong>foo <em>bar</em> baz</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6060,7 +6060,7 @@ fn spec_test_429() {
     let expected = r##"<p><strong>foo<em>bar</em>baz</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6070,7 +6070,7 @@ fn spec_test_430() {
     let expected = r##"<p><strong><em>foo</em> bar</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6080,7 +6080,7 @@ fn spec_test_431() {
     let expected = r##"<p><strong>foo <em>bar</em></strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6092,7 +6092,7 @@ bim* bop**
 bim</em> bop</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6102,7 +6102,7 @@ fn spec_test_433() {
     let expected = r##"<p><strong>foo <a href="/url"><em>bar</em></a></strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6112,7 +6112,7 @@ fn spec_test_434() {
     let expected = r##"<p>__ is not an empty emphasis</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6122,7 +6122,7 @@ fn spec_test_435() {
     let expected = r##"<p>____ is not an empty strong emphasis</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6132,7 +6132,7 @@ fn spec_test_436() {
     let expected = r##"<p>foo ***</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6142,7 +6142,7 @@ fn spec_test_437() {
     let expected = r##"<p>foo <em>*</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6152,7 +6152,7 @@ fn spec_test_438() {
     let expected = r##"<p>foo <em>_</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6162,7 +6162,7 @@ fn spec_test_439() {
     let expected = r##"<p>foo *****</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6172,7 +6172,7 @@ fn spec_test_440() {
     let expected = r##"<p>foo <strong>*</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6182,7 +6182,7 @@ fn spec_test_441() {
     let expected = r##"<p>foo <strong>_</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6192,7 +6192,7 @@ fn spec_test_442() {
     let expected = r##"<p>*<em>foo</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6202,7 +6202,7 @@ fn spec_test_443() {
     let expected = r##"<p><em>foo</em>*</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6212,7 +6212,7 @@ fn spec_test_444() {
     let expected = r##"<p>*<strong>foo</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6222,7 +6222,7 @@ fn spec_test_445() {
     let expected = r##"<p>***<em>foo</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6232,7 +6232,7 @@ fn spec_test_446() {
     let expected = r##"<p><strong>foo</strong>*</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6242,7 +6242,7 @@ fn spec_test_447() {
     let expected = r##"<p><em>foo</em>***</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6252,7 +6252,7 @@ fn spec_test_448() {
     let expected = r##"<p>foo ___</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6262,7 +6262,7 @@ fn spec_test_449() {
     let expected = r##"<p>foo <em>_</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6272,7 +6272,7 @@ fn spec_test_450() {
     let expected = r##"<p>foo <em>*</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6282,7 +6282,7 @@ fn spec_test_451() {
     let expected = r##"<p>foo _____</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6292,7 +6292,7 @@ fn spec_test_452() {
     let expected = r##"<p>foo <strong>_</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6302,7 +6302,7 @@ fn spec_test_453() {
     let expected = r##"<p>foo <strong>*</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6312,7 +6312,7 @@ fn spec_test_454() {
     let expected = r##"<p>_<em>foo</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6322,7 +6322,7 @@ fn spec_test_455() {
     let expected = r##"<p><em>foo</em>_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6332,7 +6332,7 @@ fn spec_test_456() {
     let expected = r##"<p>_<strong>foo</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6342,7 +6342,7 @@ fn spec_test_457() {
     let expected = r##"<p>___<em>foo</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6352,7 +6352,7 @@ fn spec_test_458() {
     let expected = r##"<p><strong>foo</strong>_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6362,7 +6362,7 @@ fn spec_test_459() {
     let expected = r##"<p><em>foo</em>___</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6372,7 +6372,7 @@ fn spec_test_460() {
     let expected = r##"<p><strong>foo</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6382,7 +6382,7 @@ fn spec_test_461() {
     let expected = r##"<p><em><em>foo</em></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6392,7 +6392,7 @@ fn spec_test_462() {
     let expected = r##"<p><strong>foo</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6402,7 +6402,7 @@ fn spec_test_463() {
     let expected = r##"<p><em><em>foo</em></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6412,7 +6412,7 @@ fn spec_test_464() {
     let expected = r##"<p><strong><strong>foo</strong></strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6422,7 +6422,7 @@ fn spec_test_465() {
     let expected = r##"<p><strong><strong>foo</strong></strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6432,7 +6432,7 @@ fn spec_test_466() {
     let expected = r##"<p><strong><strong><strong>foo</strong></strong></strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6442,7 +6442,7 @@ fn spec_test_467() {
     let expected = r##"<p><em><strong>foo</strong></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6452,7 +6452,7 @@ fn spec_test_468() {
     let expected = r##"<p><em><strong><strong>foo</strong></strong></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6462,7 +6462,7 @@ fn spec_test_469() {
     let expected = r##"<p><em>foo _bar</em> baz_</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6472,7 +6472,7 @@ fn spec_test_470() {
     let expected = r##"<p><em>foo <strong>bar *baz bim</strong> bam</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6482,7 +6482,7 @@ fn spec_test_471() {
     let expected = r##"<p>**foo <strong>bar baz</strong></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6492,7 +6492,7 @@ fn spec_test_472() {
     let expected = r##"<p>*foo <em>bar baz</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6502,7 +6502,7 @@ fn spec_test_473() {
     let expected = r##"<p>*<a href="/url">bar*</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6512,7 +6512,7 @@ fn spec_test_474() {
     let expected = r##"<p>_foo <a href="/url">bar_</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6522,7 +6522,7 @@ fn spec_test_475() {
     let expected = r##"<p>*<img src="foo" title="*"/></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6532,7 +6532,7 @@ fn spec_test_476() {
     let expected = r##"<p>**<a href="**"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6542,7 +6542,7 @@ fn spec_test_477() {
     let expected = r##"<p>__<a href="__"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6552,7 +6552,7 @@ fn spec_test_478() {
     let expected = r##"<p><em>a <code>*</code></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6562,7 +6562,7 @@ fn spec_test_479() {
     let expected = r##"<p><em>a <code>_</code></em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6572,7 +6572,7 @@ fn spec_test_480() {
     let expected = r##"<p>**a<a href="https://foo.bar/?q=**">https://foo.bar/?q=**</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6582,7 +6582,7 @@ fn spec_test_481() {
     let expected = r##"<p>__a<a href="https://foo.bar/?q=__">https://foo.bar/?q=__</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6592,7 +6592,7 @@ fn spec_test_482() {
     let expected = r##"<p><a href="/uri" title="title">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6602,7 +6602,7 @@ fn spec_test_483() {
     let expected = r##"<p><a href="/uri">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6612,7 +6612,7 @@ fn spec_test_484() {
     let expected = r##"<p><a href="./target.md"></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6622,7 +6622,7 @@ fn spec_test_485() {
     let expected = r##"<p><a href="">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6632,7 +6632,7 @@ fn spec_test_486() {
     let expected = r##"<p><a href="">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6642,7 +6642,7 @@ fn spec_test_487() {
     let expected = r##"<p><a href=""></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6652,7 +6652,7 @@ fn spec_test_488() {
     let expected = r##"<p>[link](/my uri)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6662,7 +6662,7 @@ fn spec_test_489() {
     let expected = r##"<p><a href="/my%20uri">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6674,7 +6674,7 @@ bar)
 bar)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6686,7 +6686,7 @@ bar>)
 bar>)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6696,7 +6696,7 @@ fn spec_test_492() {
     let expected = r##"<p><a href="b)c">a</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6706,7 +6706,7 @@ fn spec_test_493() {
     let expected = r##"<p>[link](&lt;foo&gt;)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6720,7 +6720,7 @@ fn spec_test_494() {
 [a](<b>c)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6730,7 +6730,7 @@ fn spec_test_495() {
     let expected = r##"<p><a href="(foo)">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6740,7 +6740,7 @@ fn spec_test_496() {
     let expected = r##"<p><a href="foo(and(bar))">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6750,7 +6750,7 @@ fn spec_test_497() {
     let expected = r##"<p>[link](foo(and(bar))</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6760,7 +6760,7 @@ fn spec_test_498() {
     let expected = r##"<p><a href="foo(and(bar)">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6770,7 +6770,7 @@ fn spec_test_499() {
     let expected = r##"<p><a href="foo(and(bar)">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6780,7 +6780,7 @@ fn spec_test_500() {
     let expected = r##"<p><a href="foo):">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6796,7 +6796,7 @@ fn spec_test_501() {
 <p><a href="https://example.com?foo=3#frag">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6806,7 +6806,7 @@ fn spec_test_502() {
     let expected = r##"<p><a href="foo%5Cbar">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6816,7 +6816,7 @@ fn spec_test_503() {
     let expected = r##"<p><a href="foo%20b%C3%A4">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6826,7 +6826,7 @@ fn spec_test_504() {
     let expected = r##"<p><a href="%22title%22">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6840,7 +6840,7 @@ fn spec_test_505() {
 <a href="/url" title="title">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6850,7 +6850,7 @@ fn spec_test_506() {
     let expected = r##"<p><a href="/url" title="title &quot;&quot;">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6860,7 +6860,7 @@ fn spec_test_507() {
     let expected = r##"<p><a href="/url%C2%A0%22title%22">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6870,7 +6870,7 @@ fn spec_test_508() {
     let expected = r##"<p>[link](/url "title "and" title")</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6880,7 +6880,7 @@ fn spec_test_509() {
     let expected = r##"<p><a href="/url" title="title &quot;and&quot; title">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6891,7 +6891,7 @@ fn spec_test_510() {
     let expected = r##"<p><a href="/uri" title="title">link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6901,7 +6901,7 @@ fn spec_test_511() {
     let expected = r##"<p>[link] (/uri)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6911,7 +6911,7 @@ fn spec_test_512() {
     let expected = r##"<p><a href="/uri">link [foo [bar]]</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6921,7 +6921,7 @@ fn spec_test_513() {
     let expected = r##"<p>[link] bar](/uri)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6931,7 +6931,7 @@ fn spec_test_514() {
     let expected = r##"<p>[link <a href="/uri">bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6941,7 +6941,7 @@ fn spec_test_515() {
     let expected = r##"<p><a href="/uri">link [bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6951,7 +6951,7 @@ fn spec_test_516() {
     let expected = r##"<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6961,7 +6961,7 @@ fn spec_test_517() {
     let expected = r##"<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6971,7 +6971,7 @@ fn spec_test_518() {
     let expected = r##"<p>[foo <a href="/uri">bar</a>](/uri)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6981,7 +6981,7 @@ fn spec_test_519() {
     let expected = r##"<p>[foo <em>[bar <a href="/uri">baz</a>](/uri)</em>](/uri)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -6991,7 +6991,7 @@ fn spec_test_520() {
     let expected = r##"<p><img src="uri3" alt="[foo](uri2)" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7001,7 +7001,7 @@ fn spec_test_521() {
     let expected = r##"<p>*<a href="/uri">foo*</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7011,7 +7011,7 @@ fn spec_test_522() {
     let expected = r##"<p><a href="baz*">foo *bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7021,7 +7021,7 @@ fn spec_test_523() {
     let expected = r##"<p><em>foo [bar</em> baz]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7031,7 +7031,7 @@ fn spec_test_524() {
     let expected = r##"<p>[foo <bar attr="](baz)"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7041,7 +7041,7 @@ fn spec_test_525() {
     let expected = r##"<p>[foo<code>](/uri)</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7051,7 +7051,7 @@ fn spec_test_526() {
     let expected = r##"<p>[foo<a href="https://example.com/?search=%5D(uri)">https://example.com/?search=](uri)</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7063,7 +7063,7 @@ fn spec_test_527() {
     let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7075,7 +7075,7 @@ fn spec_test_528() {
     let expected = r##"<p><a href="/uri">link [foo [bar]]</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7087,7 +7087,7 @@ fn spec_test_529() {
     let expected = r##"<p><a href="/uri">link [bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7099,7 +7099,7 @@ fn spec_test_530() {
     let expected = r##"<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7111,7 +7111,7 @@ fn spec_test_531() {
     let expected = r##"<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7123,7 +7123,7 @@ fn spec_test_532() {
     let expected = r##"<p>[foo <a href="/uri">bar</a>]<a href="/uri">ref</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7135,7 +7135,7 @@ fn spec_test_533() {
     let expected = r##"<p>[foo <em>bar <a href="/uri">baz</a></em>]<a href="/uri">ref</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7147,7 +7147,7 @@ fn spec_test_534() {
     let expected = r##"<p>*<a href="/uri">foo*</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7159,7 +7159,7 @@ fn spec_test_535() {
     let expected = r##"<p><a href="/uri">foo *bar</a>*</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7171,7 +7171,7 @@ fn spec_test_536() {
     let expected = r##"<p>[foo <bar attr="][ref]"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7183,7 +7183,7 @@ fn spec_test_537() {
     let expected = r##"<p>[foo<code>][ref]</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7195,7 +7195,7 @@ fn spec_test_538() {
     let expected = r##"<p>[foo<a href="https://example.com/?search=%5D%5Bref%5D">https://example.com/?search=][ref]</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7207,7 +7207,7 @@ fn spec_test_539() {
     let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7219,7 +7219,7 @@ fn spec_test_540() {
     let expected = r##"<p><a href="/url">ẞ</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7232,7 +7232,7 @@ fn spec_test_541() {
     let expected = r##"<p><a href="/url">Baz</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7244,7 +7244,7 @@ fn spec_test_542() {
     let expected = r##"<p>[foo] <a href="/url" title="title">bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7258,7 +7258,7 @@ fn spec_test_543() {
 <a href="/url" title="title">bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7272,7 +7272,7 @@ fn spec_test_544() {
     let expected = r##"<p><a href="/url1">bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7284,7 +7284,7 @@ fn spec_test_545() {
     let expected = r##"<p>[bar][foo!]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7297,7 +7297,7 @@ fn spec_test_546() {
 <p>[ref[]: /uri</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7310,7 +7310,7 @@ fn spec_test_547() {
 <p>[ref[bar]]: /uri</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7323,7 +7323,7 @@ fn spec_test_548() {
 <p>[[[foo]]]: /url</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7335,7 +7335,7 @@ fn spec_test_549() {
     let expected = r##"<p><a href="/uri">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7347,7 +7347,7 @@ fn spec_test_550() {
     let expected = r##"<p><a href="/uri">bar\</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7360,7 +7360,7 @@ fn spec_test_551() {
 <p>[]: /uri</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7377,7 +7377,7 @@ fn spec_test_552() {
 ]: /uri</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7389,7 +7389,7 @@ fn spec_test_553() {
     let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7401,7 +7401,7 @@ fn spec_test_554() {
     let expected = r##"<p><a href="/url" title="title"><em>foo</em> bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7413,7 +7413,7 @@ fn spec_test_555() {
     let expected = r##"<p><a href="/url" title="title">Foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7427,7 +7427,7 @@ fn spec_test_556() {
 []</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7439,7 +7439,7 @@ fn spec_test_557() {
     let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7451,7 +7451,7 @@ fn spec_test_558() {
     let expected = r##"<p><a href="/url" title="title"><em>foo</em> bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7463,7 +7463,7 @@ fn spec_test_559() {
     let expected = r##"<p>[<a href="/url" title="title"><em>foo</em> bar</a>]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7475,7 +7475,7 @@ fn spec_test_560() {
     let expected = r##"<p>[[bar <a href="/url">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7487,7 +7487,7 @@ fn spec_test_561() {
     let expected = r##"<p><a href="/url" title="title">Foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7499,7 +7499,7 @@ fn spec_test_562() {
     let expected = r##"<p><a href="/url">foo</a> bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7511,7 +7511,7 @@ fn spec_test_563() {
     let expected = r##"<p>[foo]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7523,7 +7523,7 @@ fn spec_test_564() {
     let expected = r##"<p>*<a href="/url">foo*</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7536,7 +7536,7 @@ fn spec_test_565() {
     let expected = r##"<p><a href="/url2">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7548,7 +7548,7 @@ fn spec_test_566() {
     let expected = r##"<p><a href="/url1">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7560,7 +7560,7 @@ fn spec_test_567() {
     let expected = r##"<p><a href="">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7572,7 +7572,7 @@ fn spec_test_568() {
     let expected = r##"<p><a href="/url1">foo</a>(not a link)</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7584,7 +7584,7 @@ fn spec_test_569() {
     let expected = r##"<p>[foo]<a href="/url">bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7597,7 +7597,7 @@ fn spec_test_570() {
     let expected = r##"<p><a href="/url2">foo</a><a href="/url1">baz</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7610,7 +7610,7 @@ fn spec_test_571() {
     let expected = r##"<p>[foo]<a href="/url1">bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7620,7 +7620,7 @@ fn spec_test_572() {
     let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7632,7 +7632,7 @@ fn spec_test_573() {
     let expected = r##"<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7642,7 +7642,7 @@ fn spec_test_574() {
     let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7652,7 +7652,7 @@ fn spec_test_575() {
     let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7664,7 +7664,7 @@ fn spec_test_576() {
     let expected = r##"<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7676,7 +7676,7 @@ fn spec_test_577() {
     let expected = r##"<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7686,7 +7686,7 @@ fn spec_test_578() {
     let expected = r##"<p><img src="train.jpg" alt="foo" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7696,7 +7696,7 @@ fn spec_test_579() {
     let expected = r##"<p>My <img src="/path/to/train.jpg" alt="foo bar" title="title" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7706,7 +7706,7 @@ fn spec_test_580() {
     let expected = r##"<p><img src="url" alt="foo" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7716,7 +7716,7 @@ fn spec_test_581() {
     let expected = r##"<p><img src="/url" alt="" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7728,7 +7728,7 @@ fn spec_test_582() {
     let expected = r##"<p><img src="/url" alt="foo" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7740,7 +7740,7 @@ fn spec_test_583() {
     let expected = r##"<p><img src="/url" alt="foo" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7752,7 +7752,7 @@ fn spec_test_584() {
     let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7764,7 +7764,7 @@ fn spec_test_585() {
     let expected = r##"<p><img src="/url" alt="foo bar" title="title" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7776,7 +7776,7 @@ fn spec_test_586() {
     let expected = r##"<p><img src="/url" alt="Foo" title="title" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7790,7 +7790,7 @@ fn spec_test_587() {
 []</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7802,7 +7802,7 @@ fn spec_test_588() {
     let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7814,7 +7814,7 @@ fn spec_test_589() {
     let expected = r##"<p><img src="/url" alt="foo bar" title="title" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7827,7 +7827,7 @@ fn spec_test_590() {
 <p>[[foo]]: /url "title"</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7839,7 +7839,7 @@ fn spec_test_591() {
     let expected = r##"<p><img src="/url" alt="Foo" title="title" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7851,7 +7851,7 @@ fn spec_test_592() {
     let expected = r##"<p>![foo]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7863,7 +7863,7 @@ fn spec_test_593() {
     let expected = r##"<p>!<a href="/url" title="title">foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7873,7 +7873,7 @@ fn spec_test_594() {
     let expected = r##"<p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7883,7 +7883,7 @@ fn spec_test_595() {
     let expected = r##"<p><a href="https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7893,7 +7893,7 @@ fn spec_test_596() {
     let expected = r##"<p><a href="irc://foo.bar:2233/baz">irc://foo.bar:2233/baz</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7903,7 +7903,7 @@ fn spec_test_597() {
     let expected = r##"<p><a href="MAILTO:FOO@BAR.BAZ">MAILTO:FOO@BAR.BAZ</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7913,7 +7913,7 @@ fn spec_test_598() {
     let expected = r##"<p><a href="a+b+c:d">a+b+c:d</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7923,7 +7923,7 @@ fn spec_test_599() {
     let expected = r##"<p><a href="made-up-scheme://foo,bar">made-up-scheme://foo,bar</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7933,7 +7933,7 @@ fn spec_test_600() {
     let expected = r##"<p><a href="https://../">https://../</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7943,7 +7943,7 @@ fn spec_test_601() {
     let expected = r##"<p><a href="localhost:5001/foo">localhost:5001/foo</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7953,7 +7953,7 @@ fn spec_test_602() {
     let expected = r##"<p>&lt;https://foo.bar/baz bim&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7963,7 +7963,7 @@ fn spec_test_603() {
     let expected = r##"<p><a href="https://example.com/%5C%5B%5C">https://example.com/\[\</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7973,7 +7973,7 @@ fn spec_test_604() {
     let expected = r##"<p><a href="mailto:foo@bar.example.com">foo@bar.example.com</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7983,7 +7983,7 @@ fn spec_test_605() {
     let expected = r##"<p><a href="mailto:foo+special@Bar.baz-bar0.com">foo+special@Bar.baz-bar0.com</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -7993,7 +7993,7 @@ fn spec_test_606() {
     let expected = r##"<p>&lt;foo+@bar.example.com&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8003,7 +8003,7 @@ fn spec_test_607() {
     let expected = r##"<p>&lt;&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8013,7 +8013,7 @@ fn spec_test_608() {
     let expected = r##"<p>&lt; https://foo.bar &gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8023,7 +8023,7 @@ fn spec_test_609() {
     let expected = r##"<p>&lt;m:abc&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8033,7 +8033,7 @@ fn spec_test_610() {
     let expected = r##"<p>&lt;foo.bar.baz&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8043,7 +8043,7 @@ fn spec_test_611() {
     let expected = r##"<p>https://example.com</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8053,7 +8053,7 @@ fn spec_test_612() {
     let expected = r##"<p>foo@bar.example.com</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8063,7 +8063,7 @@ fn spec_test_613() {
     let expected = r##"<p><a><bab><c2c></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8073,7 +8073,7 @@ fn spec_test_614() {
     let expected = r##"<p><a/><b2/></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8085,7 +8085,7 @@ data="foo" >
 data="foo" ></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8097,7 +8097,7 @@ _boolean zoop:33=zoop:33 />
 _boolean zoop:33=zoop:33 /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8107,7 +8107,7 @@ fn spec_test_617() {
     let expected = r##"<p>Foo <responsive-image src="foo.jpg" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8117,7 +8117,7 @@ fn spec_test_618() {
     let expected = r##"<p>&lt;33&gt; &lt;__&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8127,7 +8127,7 @@ fn spec_test_619() {
     let expected = r##"<p>&lt;a h*#ref="hi"&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8137,7 +8137,7 @@ fn spec_test_620() {
     let expected = r##"<p>&lt;a href="hi'&gt; &lt;a href=hi'&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8153,7 +8153,7 @@ foo&gt;&lt;bar/ &gt;
 bim!bop /&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8163,7 +8163,7 @@ fn spec_test_622() {
     let expected = r##"<p>&lt;a href='bar'title=title&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8173,7 +8173,7 @@ fn spec_test_623() {
     let expected = r##"<p></a></foo ></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8183,7 +8183,7 @@ fn spec_test_624() {
     let expected = r##"<p>&lt;/a href="foo"&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8195,7 +8195,7 @@ comment - with hyphens -->
 comment - with hyphens --></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8208,7 +8208,7 @@ foo <!---> foo -->
 <p>foo <!---> foo --&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8218,7 +8218,7 @@ fn spec_test_627() {
     let expected = r##"<p>foo <?php echo $a; ?></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8228,7 +8228,7 @@ fn spec_test_628() {
     let expected = r##"<p>foo <!ELEMENT br EMPTY></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8238,7 +8238,7 @@ fn spec_test_629() {
     let expected = r##"<p>foo <![CDATA[>&<]]></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8248,7 +8248,7 @@ fn spec_test_630() {
     let expected = r##"<p>foo <a href="&ouml;"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8258,7 +8258,7 @@ fn spec_test_631() {
     let expected = r##"<p>foo <a href="\*"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8268,7 +8268,7 @@ fn spec_test_632() {
     let expected = r##"<p>&lt;a href="""&gt;</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8280,7 +8280,7 @@ baz
 baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8292,7 +8292,7 @@ baz
 baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8304,7 +8304,7 @@ baz
 baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8316,7 +8316,7 @@ fn spec_test_636() {
 bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8328,7 +8328,7 @@ fn spec_test_637() {
 bar</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8340,7 +8340,7 @@ bar*
 bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8352,7 +8352,7 @@ bar*
 bar</em></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8363,7 +8363,7 @@ span`
     let expected = r##"<p><code>code   span</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8374,7 +8374,7 @@ span`
     let expected = r##"<p><code>code\ span</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8386,7 +8386,7 @@ bar">
 bar"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8398,7 +8398,7 @@ bar">
 bar"></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8408,7 +8408,7 @@ fn spec_test_644() {
     let expected = r##"<p>foo\</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8418,7 +8418,7 @@ fn spec_test_645() {
     let expected = r##"<p>foo</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8428,7 +8428,7 @@ fn spec_test_646() {
     let expected = r##"<h3>foo\</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8438,7 +8438,7 @@ fn spec_test_647() {
     let expected = r##"<h3>foo</h3>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8450,7 +8450,7 @@ baz
 baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8462,7 +8462,7 @@ fn spec_test_649() {
 baz</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8472,7 +8472,7 @@ fn spec_test_650() {
     let expected = r##"<p>hello $.;'there</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8482,7 +8482,7 @@ fn spec_test_651() {
     let expected = r##"<p>Foo χρῆν</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -8492,5 +8492,5 @@ fn spec_test_652() {
     let expected = r##"<p>Multiple     spaces</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/strikethrough.rs
+++ b/pulldown-cmark/tests/suite/strikethrough.rs
@@ -10,7 +10,7 @@ fn strikethrough_test_1() {
     let expected = r##"<p><del>This is <em>stricken out</em></del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn strikethrough_test_2() {
     let expected = r##"<p><del>This is ~~stricken</del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn strikethrough_test_3() {
     let expected = r##"<p>This<del>is</del>stricken</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn strikethrough_test_4() {
     let expected = r##"<p><del>This</del>is<del>stricken</del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn strikethrough_test_5() {
     let expected = r##"<p>Here I strike out an exclamation point<del>!</del>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn strikethrough_test_6() {
     let expected = r##"<p><del>This is stricken out</del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn strikethrough_test_7() {
     let expected = r##"<p><del>This is ~stricken</del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn strikethrough_test_8() {
     let expected = r##"<p>This~is~nothing</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -90,7 +90,7 @@ fn strikethrough_test_9() {
     let expected = r##"<p><del>This~is~nothing</del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn strikethrough_test_10() {
     let expected = r##"<p>Here I fail to strike out an exclamation point~!~.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn strikethrough_test_11() {
     let expected = r##"<p>Here I fail to strike out a tilde ~~~.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn strikethrough_test_12() {
     let expected = r##"<p>Here I fail to match up ~~tildes~.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn strikethrough_test_13() {
     let expected = r##"<p>Here I fail to match up ~tildes~~.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -140,7 +140,7 @@ fn strikethrough_test_14() {
     let expected = r##"<p><del>This ~is stricken.</del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -150,5 +150,5 @@ fn strikethrough_test_15() {
     let expected = r##"<p><del>This ~~is stricken.</del></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/super_sub.rs
+++ b/pulldown-cmark/tests/suite/super_sub.rs
@@ -10,7 +10,7 @@ fn super_sub_test_1() {
     let expected = r##"<p><sup>This is super</sup> <sub>This is sub</sub></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, true, false);
+    test_markdown_html(original, expected, false, false, false, true, false, false);
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn super_sub_test_2() {
     let expected = r##"<p><sub>This is stricken out</sub></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, true, false);
+    test_markdown_html(original, expected, false, false, false, true, false, false);
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn super_sub_test_3() {
     let expected = r##"<p><sub>This is ~stricken</sub></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, true, false);
+    test_markdown_html(original, expected, false, false, false, true, false, false);
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn super_sub_test_4() {
     let expected = r##"<p><sub>This~is~nothing</sub></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, true, false);
+    test_markdown_html(original, expected, false, false, false, true, false, false);
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn super_sub_test_5() {
     let expected = r##"<p><sub>This ~~is stricken.</sub></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, true, false);
+    test_markdown_html(original, expected, false, false, false, true, false, false);
 }
 
 #[test]
@@ -60,5 +60,5 @@ fn super_sub_test_6() {
     let expected = r##"<p><sub>This ~~is stricken</sub> but this is not~~</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, true, false);
+    test_markdown_html(original, expected, false, false, false, true, false, false);
 }

--- a/pulldown-cmark/tests/suite/table.rs
+++ b/pulldown-cmark/tests/suite/table.rs
@@ -11,7 +11,7 @@ fn table_test_1() {
     let expected = r##"<h2>Test header</h2>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn table_test_2() {
 </table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn table_test_3() {
 </blockquote>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn table_test_4() {
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn table_test_5() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn table_test_6() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn table_test_7() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -135,7 +135,7 @@ fn table_test_8() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn table_test_9() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn table_test_10() {
 |ぃ|い|</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -187,7 +187,7 @@ fn table_test_11() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -201,7 +201,7 @@ fn table_test_12() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -302,7 +302,7 @@ b</p>
 <p>b</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -316,7 +316,7 @@ fn table_test_14() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -332,7 +332,7 @@ fn table_test_15() {
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -348,7 +348,7 @@ fn table_test_16() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -398,7 +398,7 @@ fn table_test_17() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -436,7 +436,7 @@ fn table_test_18() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -466,7 +466,7 @@ fn table_test_19() {
 | Not   | Enough |</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -480,7 +480,7 @@ fn table_test_20() {
 <p>|</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -494,7 +494,7 @@ fn table_test_21() {
 | Table | Body   |</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -516,7 +516,7 @@ fn table_test_22() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -542,7 +542,7 @@ fn table_test_23() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -564,7 +564,7 @@ A: Interrupting —?</p>
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -578,7 +578,7 @@ fn table_test_25() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -592,7 +592,7 @@ fn table_test_26() {
 </tbody></table>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -610,7 +610,7 @@ moo | moo
 </ul>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }
 
 #[test]
@@ -628,5 +628,5 @@ moo | moo
 </ol>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, false);
+    test_markdown_html(original, expected, false, false, false, false, false, false);
 }

--- a/pulldown-cmark/tests/suite/wikilinks.rs
+++ b/pulldown-cmark/tests/suite/wikilinks.rs
@@ -10,7 +10,7 @@ fn wikilinks_test_1() {
     let expected = r##"<p>This is a <a href="WikiLink">WikiLink</a>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn wikilinks_test_2() {
     let expected = r##"<p>This is a <a href="Main/WikiLink">Main/WikiLink</a>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn wikilinks_test_3() {
     let expected = r##"<p>This is <a href="Ambiguous">Ambiguous</a>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn wikilinks_test_4() {
 </p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn wikilinks_test_5() {
     let expected = r##"<p>This is [also <a href="Ambiguous">Ambiguous</a>](https://example.com/).</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn wikilinks_test_6() {
 <p><a href="https://example.org/">https://example.org/</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn wikilinks_test_7() {
     let expected = r##"<p>This is <a href="WikiLink">a pothole</a>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn wikilinks_test_8() {
     let expected = r##"<p>This is a <a href="WikiLink/In/A/Directory">WikiLink</a>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn wikilinks_test_9() {
     let expected = r##"<p>This is <a href="WikiLink">a <strong>strong</strong> pothole</a>.</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -117,7 +117,7 @@ fn wikilinks_test_10() {
 </p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -127,7 +127,7 @@ fn wikilinks_test_11() {
     let expected = r##"<p>[[WikiLink|<a href="Fish">Fish</a>]]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -137,7 +137,7 @@ fn wikilinks_test_12() {
     let expected = r##"<p>[[WikiLink|<a href="cat.html">cat</a>]]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn wikilinks_test_13() {
 </p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -162,7 +162,7 @@ fn wikilinks_test_14() {
     let expected = r##"<p><img src="dog.png" alt="a cute dog" /></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -172,7 +172,7 @@ fn wikilinks_test_15() {
     let expected = r##"<p>]] [[]] [[|]] [[|Symbol]] [[</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn wikilinks_test_16() {
     let expected = r##"<p><a href="%5B%5Burl%5D%5D">inline link</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -192,7 +192,7 @@ fn wikilinks_test_17() {
     let expected = r##"<p><a href="%5B%5Burl">inline link</a>]]</p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn wikilinks_test_18() {
     let expected = r##"<p><code>[[code]]</code></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -212,7 +212,7 @@ fn wikilinks_test_19() {
     let expected = r##"<p>emphasis **cross <a href="over**%20here">over** here</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn wikilinks_test_20() {
     let expected = r##"<p><a href="first%5C">second</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }
 
 #[test]
@@ -232,5 +232,5 @@ fn wikilinks_test_21() {
     let expected = r##"<p><a href="first&amp;#33;second">first&amp;#33;second</a></p>
 "##;
 
-    test_markdown_html(original, expected, false, false, false, false, true);
+    test_markdown_html(original, expected, false, false, false, false, true, false);
 }


### PR DESCRIPTION
Fixes #997

The first commit adds an example label for deflists, because it makes it easier to make sure we're testing GFM stuff with exactly the set of features that GFM has.