### PR TITLE
Make flanking behavior on `~` and `^` act closer to pandoc

### DIFF
--- a/pulldown-cmark/specs/super_sub.txt
+++ b/pulldown-cmark/specs/super_sub.txt
@@ -25,13 +25,19 @@ Backslash escapes:
 ```````````````````````````````` example_super_sub
 ~This~is~nothing~
 .
-<p><sub>This~is~nothing</sub></p>
+<p><sub>This</sub>is<sub>nothing</sub></p>
 ````````````````````````````````
 
 ```````````````````````````````` example_super_sub
-~This ~~is stricken.~
+~This ~~is not stricken.~
 .
-<p><sub>This ~~is stricken.</sub></p>
+<p><sub>This ~~is not stricken.</sub></p>
+````````````````````````````````
+
+```````````````````````````````` example_super_sub
+~~This ~is~~ stricken.~
+.
+<p><del>This ~is</del> stricken.~</p>
 ````````````````````````````````
 
 The first one wins.
@@ -40,4 +46,16 @@ The first one wins.
 ~This ~~is stricken~ but this is not~~
 .
 <p><sub>This ~~is stricken</sub> but this is not~~</p>
+````````````````````````````````
+
+Though strikethrough requires left and right flanking, subscript does not.
+Neither does superscript.
+
+```````````````````````````````` example_super_sub
+H~2~O
+
+y=x^2^a+xb+c
+.
+<p>H<sub>2</sub>O</p>
+<p>y=x<sup>2</sup>a+xb+c</p>
 ````````````````````````````````

--- a/pulldown-cmark/tests/suite/super_sub.rs
+++ b/pulldown-cmark/tests/suite/super_sub.rs
@@ -37,7 +37,7 @@ fn super_sub_test_3() {
 fn super_sub_test_4() {
     let original = r##"~This~is~nothing~
 "##;
-    let expected = r##"<p><sub>This~is~nothing</sub></p>
+    let expected = r##"<p><sub>This</sub>is<sub>nothing</sub></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false, true, false, false);
@@ -45,9 +45,9 @@ fn super_sub_test_4() {
 
 #[test]
 fn super_sub_test_5() {
-    let original = r##"~This ~~is stricken.~
+    let original = r##"~This ~~is not stricken.~
 "##;
-    let expected = r##"<p><sub>This ~~is stricken.</sub></p>
+    let expected = r##"<p><sub>This ~~is not stricken.</sub></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false, true, false, false);
@@ -55,9 +55,32 @@ fn super_sub_test_5() {
 
 #[test]
 fn super_sub_test_6() {
+    let original = r##"~~This ~is~~ stricken.~
+"##;
+    let expected = r##"<p><del>This ~is</del> stricken.~</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, true, false, false);
+}
+
+#[test]
+fn super_sub_test_7() {
     let original = r##"~This ~~is stricken~ but this is not~~
 "##;
     let expected = r##"<p><sub>This ~~is stricken</sub> but this is not~~</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, true, false, false);
+}
+
+#[test]
+fn super_sub_test_8() {
+    let original = r##"H~2~O
+
+y=x^2^a+xb+c
+"##;
+    let expected = r##"<p>H<sub>2</sub>O</p>
+<p>y=x<sup>2</sup>a+xb+c</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false, true, false, false);


### PR DESCRIPTION
Fixes #1022