### PR TITLE
Do not use the same lower limit for `^` and `~`

### DIFF
--- a/pulldown-cmark/specs/super_sub.txt
+++ b/pulldown-cmark/specs/super_sub.txt
@@ -59,3 +59,26 @@ y=x^2^a+xb+c
 <p>H<sub>2</sub>O</p>
 <p>y=x<sup>2</sup>a+xb+c</p>
 ````````````````````````````````
+
+Superscript and subscript cannot group with a different delimiter count.
+
+```````````````````````````````` example_super_sub
+~foo~~
+
+^bar^^
+.
+<p>~foo~~</p>
+<p>^bar^^</p>
+````````````````````````````````
+
+The lower bound of superscript and subscript are separate.
+Emphasis example included for analogy.
+
+```````````````````````````````` example_super_sub
+~foo^~^bar~
+
+*foo_*_bar*
+.
+<p><sub>foo^</sub>^bar~</p>
+<p><em>foo_</em>_bar*</p>
+````````````````````````````````

--- a/pulldown-cmark/tests/suite/super_sub.rs
+++ b/pulldown-cmark/tests/suite/super_sub.rs
@@ -85,3 +85,29 @@ y=x^2^a+xb+c
 
     test_markdown_html(original, expected, false, false, false, true, false, false);
 }
+
+#[test]
+fn super_sub_test_9() {
+    let original = r##"~foo~~
+
+^bar^^
+"##;
+    let expected = r##"<p>~foo~~</p>
+<p>^bar^^</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, true, false, false);
+}
+
+#[test]
+fn super_sub_test_10() {
+    let original = r##"~foo^~^bar~
+
+*foo_*_bar*
+"##;
+    let expected = r##"<p><sub>foo^</sub>^bar~</p>
+<p><em>foo_</em>_bar*</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, true, false, false);
+}


### PR DESCRIPTION
This fixes some inconsistent behavior between superscript, subscript, and emphasis.