### PR TITLE
Expose Event::HardBreak style

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ example, is the code to transform soft line breaks into hard breaks:
 
 ```rust
 let parser = parser.map(|event| match event {
-	Event::SoftBreak => Event::HardBreak(..),
+	Event::SoftBreak => Event::HardBreak(HardBreakStyle::DoubleSpace),
 	_ => event
 });
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ example, is the code to transform soft line breaks into hard breaks:
 
 ```rust
 let parser = parser.map(|event| match event {
-	Event::SoftBreak => Event::HardBreak(HardBreakStyle::DoubleSpace),
+	Event::SoftBreak => Event::HardBreak(HardBreakKind::Spaces),
 	_ => event
 });
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ example, is the code to transform soft line breaks into hard breaks:
 
 ```rust
 let parser = parser.map(|event| match event {
-	Event::SoftBreak => Event::HardBreak,
+	Event::SoftBreak => Event::HardBreak(..),
 	_ => event
 });
 ```

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -279,7 +279,7 @@ pub fn xml_to_events(xml: &str) -> anyhow::Result<Vec<Event>> {
             XmlEvent::Empty(tag) => match tag.name().as_ref() {
                 b"thematic_break" => events.push(Event::Rule),
                 b"softbreak" => events.push(Event::SoftBreak),
-                b"linebreak" => events.push(Event::HardBreak),
+                b"linebreak" => events.push(Event::HardBreak(HardBreakStyle::BackSlash)),
                 name => anyhow::bail!("empty tag: {}", String::from_utf8_lossy(name)),
             },
             event => anyhow::bail!("event {event:?}"),

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -13,7 +13,7 @@ use mozjs::rooted;
 use mozjs::rust::wrappers::JS_CallFunctionName;
 use mozjs::rust::SIMPLE_GLOBAL_CLASS;
 use mozjs::rust::{JSEngine, RealmOptions, Runtime};
-use pulldown_cmark::{CodeBlockKind, Event, HardBreakStyle, LinkType, Parser, Tag, TagEnd};
+use pulldown_cmark::{CodeBlockKind, Event, HardBreakKind, LinkType, Parser, Tag, TagEnd};
 use quick_xml::escape::unescape;
 use quick_xml::events::Event as XmlEvent;
 use quick_xml::reader::Reader;
@@ -279,7 +279,7 @@ pub fn xml_to_events(xml: &str) -> anyhow::Result<Vec<Event>> {
             XmlEvent::Empty(tag) => match tag.name().as_ref() {
                 b"thematic_break" => events.push(Event::Rule),
                 b"softbreak" => events.push(Event::SoftBreak),
-                b"linebreak" => events.push(Event::HardBreak(HardBreakStyle::BackSlash)),
+                b"linebreak" => events.push(Event::HardBreak(HardBreakKind::BackSlash)),
                 name => anyhow::bail!("empty tag: {}", String::from_utf8_lossy(name)),
             },
             event => anyhow::bail!("event {event:?}"),
@@ -302,7 +302,7 @@ pub fn xml_to_events(xml: &str) -> anyhow::Result<Vec<Event>> {
 ///
 /// - Resets all code blocks to `CodeBlockKind::Fenced`.
 ///
-/// - Make all `HardBreak`s into `HardBreak(HardBreakStyle::BackSlash)`.
+/// - Make all `HardBreak`s into `HardBreak(HardBreakKind::BackSlash)`.
 pub fn normalize(events: Vec<Event<'_>>) -> Vec<Event<'_>> {
     let mut normalized = Vec::with_capacity(events.len());
     for event in events.into_iter() {
@@ -335,7 +335,7 @@ pub fn normalize(events: Vec<Event<'_>>) -> Vec<Event<'_>> {
 
             // As commonmark.js doesn't differentiate between hard break stylings:
             (_, Event::HardBreak(_)) => {
-                normalized.push(Event::HardBreak(HardBreakStyle::BackSlash))
+                normalized.push(Event::HardBreak(HardBreakKind::BackSlash))
             }
 
             // Other events are passed through.

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -334,9 +334,7 @@ pub fn normalize(events: Vec<Event<'_>>) -> Vec<Event<'_>> {
             }
 
             // As commonmark.js doesn't differentiate between hard break stylings:
-            (_, Event::HardBreak(_)) => {
-                normalized.push(Event::HardBreak(HardBreakKind::BackSlash))
-            }
+            (_, Event::HardBreak(_)) => normalized.push(Event::HardBreak(HardBreakKind::BackSlash)),
 
             // Other events are passed through.
             (_, _) => normalized.push(event),

--- a/guide/src/index.md
+++ b/guide/src/index.md
@@ -53,7 +53,7 @@ example, is the code to transform soft line breaks into hard breaks:
 
 ```rust
 let parser = parser.map(|event| match event {
-	Event::SoftBreak => Event::HardBreak(..),
+	Event::SoftBreak => Event::HardBreak(HardBreakStyle::DoubleSpace),
 	_ => event
 });
 ```

--- a/guide/src/index.md
+++ b/guide/src/index.md
@@ -53,7 +53,7 @@ example, is the code to transform soft line breaks into hard breaks:
 
 ```rust
 let parser = parser.map(|event| match event {
-	Event::SoftBreak => Event::HardBreak(HardBreakStyle::DoubleSpace),
+	Event::SoftBreak => Event::HardBreak(HardBreakKind::Spaces),
 	_ => event
 });
 ```

--- a/guide/src/index.md
+++ b/guide/src/index.md
@@ -53,7 +53,7 @@ example, is the code to transform soft line breaks into hard breaks:
 
 ```rust
 let parser = parser.map(|event| match event {
-	Event::SoftBreak => Event::HardBreak,
+	Event::SoftBreak => Event::HardBreak(..),
 	_ => event
 });
 ```

--- a/pulldown-cmark/examples/parser-map-event-print.rs
+++ b/pulldown-cmark/examples/parser-map-event-print.rs
@@ -24,7 +24,7 @@ fn main() {
             Event::FootnoteReference(s) => println!("FootnoteReference: {:?}", s),
             Event::TaskListMarker(b) => println!("TaskListMarker: {:?}", b),
             Event::SoftBreak => println!("SoftBreak"),
-            Event::HardBreak => println!("HardBreak"),
+            Event::HardBreak(s) => println!("HardBreak: {:?}", s),
             Event::Rule => println!("Rule"),
         };
         event

--- a/pulldown-cmark/src/html.rs
+++ b/pulldown-cmark/src/html.rs
@@ -131,7 +131,7 @@ where
                 SoftBreak => {
                     self.write_newline()?;
                 }
-                HardBreak => {
+                HardBreak(_) => {
                     self.write("<br />\n")?;
                 }
                 Rule => {
@@ -510,7 +510,7 @@ where
                     escape_html(&mut self.writer, &text)?;
                     self.write("$$")?;
                 }
-                SoftBreak | HardBreak | Rule => {
+                SoftBreak | HardBreak(_) | Rule => {
                     self.write(" ")?;
                 }
                 FootnoteReference(name) => {

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -114,8 +114,8 @@ use core::fmt::Display;
 
 pub use crate::{
     parse::{
-        BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback,
-        OffsetIter, Parser, RefDefs, HardBreakStyle
+        BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback, HardBreakStyle, OffsetIter,
+        Parser, RefDefs,
     },
     strings::{CowStr, InlineStr},
     utils::*,

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -114,7 +114,8 @@ use core::fmt::Display;
 
 pub use crate::{
     parse::{
-        BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback, OffsetIter, Parser, RefDefs,
+        BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback,
+        OffsetIter, Parser, RefDefs, HardBreakStyle
     },
     strings::{CowStr, InlineStr},
     utils::*,
@@ -610,7 +611,7 @@ pub enum Event<'a> {
     /// breaks
     /// ```
     /// *`·` is a space*
-    HardBreak,
+    HardBreak(HardBreakStyle),
     /// A horizontal ruler.
     ///
     /// ```markdown
@@ -642,7 +643,7 @@ impl<'a> Event<'a> {
             Event::InlineHtml(s) => Event::InlineHtml(s.into_static()),
             Event::FootnoteReference(s) => Event::FootnoteReference(s.into_static()),
             Event::SoftBreak => Event::SoftBreak,
-            Event::HardBreak => Event::HardBreak,
+            Event::HardBreak(style) => Event::HardBreak(style),
             Event::Rule => Event::Rule,
             Event::TaskListMarker(b) => Event::TaskListMarker(b),
         }

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -114,7 +114,7 @@ use core::fmt::Display;
 
 pub use crate::{
     parse::{
-        BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback, HardBreakStyle, OffsetIter,
+        BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback, HardBreakKind, OffsetIter,
         Parser, RefDefs,
     },
     strings::{CowStr, InlineStr},
@@ -611,7 +611,7 @@ pub enum Event<'a> {
     /// breaks
     /// ```
     /// *`·` is a space*
-    HardBreak(HardBreakStyle),
+    HardBreak(HardBreakKind),
     /// A horizontal ruler.
     ///
     /// ```markdown

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -184,7 +184,7 @@ impl ItemBody {
 
 /// The style of an [`Event::HardBreak`].
 #[derive(Clone, Debug, PartialEq)]
-pub enum HardBreakStyle {
+pub enum HardBreakKind {
     /// ```plain
     /// Line break!\
     /// ```
@@ -192,15 +192,15 @@ pub enum HardBreakStyle {
     /// ```plain
     /// Line break!··
     /// ```
-    DoubleSpace,
+    Spaces,
 }
 
-impl HardBreakStyle {
+impl HardBreakKind {
     const fn from_bool(src: bool) -> Self {
         if src {
             Self::BackSlash
         } else {
-            Self::DoubleSpace
+            Self::Spaces
         }
     }
 }
@@ -2298,7 +2298,7 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &mut Allocations<'a>) ->
         ItemBody::InlineHtml => return Event::InlineHtml(text[item.start..item.end].into()),
         ItemBody::OwnedInlineHtml(cow_ix) => return Event::InlineHtml(allocs.take_cow(cow_ix)),
         ItemBody::SoftBreak => return Event::SoftBreak,
-        ItemBody::HardBreak(style) => return Event::HardBreak(HardBreakStyle::from_bool(style)),
+        ItemBody::HardBreak(style) => return Event::HardBreak(HardBreakKind::from_bool(style)),
         ItemBody::FootnoteReference(cow_ix) => {
             return Event::FootnoteReference(allocs.take_cow(cow_ix))
         }

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -192,7 +192,7 @@ pub enum HardBreakStyle {
     /// ```plain
     /// Line break!··
     /// ```
-    DoubleSpace
+    DoubleSpace,
 }
 
 impl HardBreakStyle {

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -182,6 +182,29 @@ impl ItemBody {
     }
 }
 
+/// The style of an [`Event::HardBreak`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum HardBreakStyle {
+    /// ```plain
+    /// Line break!\
+    /// ```
+    BackSlash,
+    /// ```plain
+    /// Line break!··
+    /// ```
+    DoubleSpace
+}
+
+impl HardBreakStyle {
+    const fn from_bool(src: bool) -> Self {
+        if src {
+            Self::BackSlash
+        } else {
+            Self::DoubleSpace
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct BrokenLink<'a> {
     pub span: core::ops::Range<usize>,
@@ -2275,7 +2298,7 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &mut Allocations<'a>) ->
         ItemBody::InlineHtml => return Event::InlineHtml(text[item.start..item.end].into()),
         ItemBody::OwnedInlineHtml(cow_ix) => return Event::InlineHtml(allocs.take_cow(cow_ix)),
         ItemBody::SoftBreak => return Event::SoftBreak,
-        ItemBody::HardBreak(_) => return Event::HardBreak,
+        ItemBody::HardBreak(style) => return Event::HardBreak(HardBreakStyle::from_bool(style)),
         ItemBody::FootnoteReference(cow_ix) => {
             return Event::FootnoteReference(allocs.take_cow(cow_ix))
         }


### PR DESCRIPTION
Being that this information is already parsed into ItemBody and the user might want to behave differently depending on the style (either backslash or double spaced) of the hardbreak

I think it's the best option to expose it as a new enum.

This issue came up in Clippy, we has to do very weird things to get the hardbreak style, and results in performance issues. Sorry if this is controversial enough to need an issue.