### PR TITLE
Make Event::FootNoteReference documentation accurate

### DIFF
--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -587,7 +587,7 @@ pub enum Event<'a> {
     /// **Note**: Under some conditions HTML can also be parsed as an HTML Block, see [`Tag::HtmlBlock`] for details.
     #[cfg_attr(feature = "serde", serde(borrow))]
     InlineHtml(CowStr<'a>),
-    /// A reference to a footnote with given label, which may or may not be defined
+    /// A reference to a footnote with given label, defined
     /// by an event with a [`Tag::FootnoteDefinition`] tag. Definitions and references to them may
     /// occur in any order. Only parsed and emitted with [`Options::ENABLE_FOOTNOTES`] or [`Options::ENABLE_OLD_FOOTNOTES`].
     ///


### PR DESCRIPTION
Just a documentation change, as @notriddle said that they **need** to have a definition now. 