### PR TITLE
Rename BrokenLinkCallback trait to ParserCallbacks

### DIFF
--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -113,9 +113,7 @@ mod tree;
 use core::fmt::Display;
 
 pub use crate::{
-    parse::{
-        BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback, OffsetIter, Parser, RefDefs,
-    },
+    parse::{BrokenLink, DefaultParserCallbacks, OffsetIter, Parser, ParserCallbacks, RefDefs},
     strings::{CowStr, InlineStr},
     utils::*,
 };

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -113,7 +113,10 @@ mod tree;
 use core::fmt::Display;
 
 pub use crate::{
-    parse::{BrokenLink, DefaultParserCallbacks, OffsetIter, Parser, ParserCallbacks, RefDefs},
+    parse::{
+        BrokenLink, BrokenLinkCallback, DefaultParserCallbacks, OffsetIter, Parser,
+        ParserCallbacks, RefDefs,
+    },
     strings::{CowStr, InlineStr},
     utils::*,
 };

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -2133,8 +2133,10 @@ pub(crate) struct HtmlScanGuard {
 pub trait ParserCallbacks<'input> {
     fn handle_broken_link(
         &mut self,
-        link: BrokenLink<'input>,
-    ) -> Option<(CowStr<'input>, CowStr<'input>)>;
+        #[allow(unused_variables)] link: BrokenLink<'input>,
+    ) -> Option<(CowStr<'input>, CowStr<'input>)> {
+        None
+    }
 }
 
 impl<'input, T> ParserCallbacks<'input> for T
@@ -2162,14 +2164,7 @@ impl<'input> ParserCallbacks<'input> for Box<dyn ParserCallbacks<'input>> {
 #[derive(Debug)]
 pub struct DefaultParserCallbacks;
 
-impl<'input> ParserCallbacks<'input> for DefaultParserCallbacks {
-    fn handle_broken_link(
-        &mut self,
-        _link: BrokenLink<'input>,
-    ) -> Option<(CowStr<'input>, CowStr<'input>)> {
-        None
-    }
-}
+impl<'input> ParserCallbacks<'input> for DefaultParserCallbacks {}
 
 /// Markdown event and source range iterator.
 ///

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -267,6 +267,30 @@ impl<'input> Parser<'input, DefaultParserCallbacks> {
 }
 
 impl<'input, CB: ParserCallbacks<'input>> Parser<'input, CB> {
+    /// Creates a new event iterator for markdown text with given options and optionally, callbacks.
+    ///
+    /// ```
+    /// # use pulldown_cmark::{BrokenLink, CowStr, Event, Options, Parser, ParserCallbacks, Tag};
+    /// struct CustomCallbacks;
+    /// impl<'input> ParserCallbacks<'input> for CustomCallbacks {
+    ///     fn handle_broken_link(
+    ///         &mut self,
+    ///         link: BrokenLink<'input>,
+    ///     ) -> Option<(CowStr<'input>, CowStr<'input>)> {
+    ///         Some(("https://target".into(), link.reference))
+    ///     }
+    /// }
+    ///
+    /// let mut parser =
+    ///     Parser::new_with_callbacks("[broken]", Options::empty(), Some(CustomCallbacks));
+    ///
+    /// assert!(matches!(
+    ///     parser.nth(1),
+    ///     Some(Event::Start(Tag::Link { .. }))
+    /// ));
+    /// ```
+    ///
+    /// See the [`ParserCallbacks`] trait for a list of callbacks that can be overridden.
     pub fn new_with_callbacks(text: &'input str, options: Options, callbacks: Option<CB>) -> Self {
         let (mut tree, allocs) = run_first_pass(text, options);
         tree.reset();
@@ -308,20 +332,23 @@ impl<'input, CB: ParserCallbacks<'input>> Parser<'input, CB> {
     }
 }
 
-impl<'input, F> Parser<'input, BrokenLinkCallback<F>>
-where
-    BrokenLinkCallback<F>: ParserCallbacks<'input>,
-{
+impl<'input, F> Parser<'input, BrokenLinkCallback<F>> {
     /// In case the parser encounters any potential links that have a broken
     /// reference (e.g `[foo]` when there is no `[foo]: ` entry at the bottom)
     /// the provided callback will be called with the reference name,
     /// and the returned pair will be used as the link URL and title if it is not
     /// `None`.
+    ///
+    /// This constructor is provided for backwards compatibility.
+    /// This and other callbacks can also be customized with [`Parser::new_with_callbacks`].
     pub fn new_with_broken_link_callback(
         text: &'input str,
         options: Options,
         broken_link_callback: Option<F>,
-    ) -> Self {
+    ) -> Self
+    where
+        F: FnMut(BrokenLink<'input>) -> Option<(CowStr<'input>, CowStr<'input>)>,
+    {
         Self::new_with_callbacks(text, options, broken_link_callback.map(BrokenLinkCallback))
     }
 }
@@ -2138,8 +2165,17 @@ pub(crate) struct HtmlScanGuard {
     pub comment: usize,
 }
 
-/// Trait to customize [`Parser`] behavior with callbacks.
+/// Trait to customize [`Parser`] behavior with callbacks. See [`Parser::new_with_callbacks`].
+///
+/// All methods have a default implementation, so you can choose which ones to override.
 pub trait ParserCallbacks<'input> {
+    /// Potentially provide a custom definition for a broken link.
+    ///
+    /// In case the parser encounters any potential links that have a broken
+    /// reference (e.g `[foo]` when there is no `[foo]: ` entry at the bottom)
+    /// this callback will be called with information about the reference,
+    /// and the returned pair will be used as the link URL and title if it is not
+    /// `None`.
     fn handle_broken_link(
         &mut self,
         #[allow(unused_variables)] link: BrokenLink<'input>,
@@ -2148,7 +2184,9 @@ pub trait ParserCallbacks<'input> {
     }
 }
 
-/// TODO: doc
+/// Wrapper to implement [`ParserCallbacks::handle_broken_link`] with a closure.
+///
+/// Used internally by [`Parser::new_with_broken_link_callback`].
 #[allow(missing_debug_implementations)]
 pub struct BrokenLinkCallback<F>(F);
 

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -404,7 +404,7 @@ impl<'input> ParserInner<'input> {
     /// inline markup passes are run on the remainder of the chain.
     ///
     /// Note: there's some potential for optimization here, but that's future work.
-    fn handle_inline(&mut self, callbacks: &mut Option<&mut dyn ParserCallbacks<'input>>) {
+    fn handle_inline(&mut self, callbacks: Option<&mut dyn ParserCallbacks<'input>>) {
         self.handle_inline_pass1(callbacks);
         self.handle_emphasis_and_hard_break();
     }
@@ -414,7 +414,7 @@ impl<'input> ParserInner<'input> {
     /// This function handles both inline HTML and code spans, because they have
     /// the same precedence. It also handles links, even though they have lower
     /// precedence, because the URL of links must not be processed.
-    fn handle_inline_pass1(&mut self, callbacks: &mut Option<&mut dyn ParserCallbacks<'input>>) {
+    fn handle_inline_pass1(&mut self, mut callbacks: Option<&mut dyn ParserCallbacks<'input>>) {
         let mut cur = self.tree.cur();
         let mut prev = None;
 
@@ -840,7 +840,7 @@ impl<'input> ParserInner<'input> {
                                         link_label,
                                         (self.tree[tos.node].item.start)..end,
                                         link_type,
-                                        callbacks,
+                                        &mut callbacks,
                                     )
                                 {
                                     let link_ix =
@@ -2232,7 +2232,7 @@ impl<'a, CB: ParserCallbacks<'a>> FusedIterator for Parser<'a, CB> {}
 impl<'input> ParserInner<'input> {
     fn next_event_range(
         &mut self,
-        mut callbacks: Option<&mut dyn ParserCallbacks<'input>>,
+        callbacks: Option<&mut dyn ParserCallbacks<'input>>,
     ) -> Option<(Event<'input>, Range<usize>)> {
         match self.tree.cur() {
             None => {
@@ -2259,7 +2259,7 @@ impl<'input> ParserInner<'input> {
                     cur_ix
                 };
                 if self.tree[cur_ix].item.body.is_maybe_inline() {
-                    self.handle_inline(&mut callbacks);
+                    self.handle_inline(callbacks);
                 }
 
                 let node = self.tree[cur_ix];


### PR DESCRIPTION
We want to use the same trait for other callbacks as well, e.g. as in #1013 #1043.

Since there will be more callbacks to override, it makes sense to remove the existing blanket implementation for closures. To keep backwards compatibility with most old use cases, `new_with_broken_link_callback` uses a new wrapper type.

I tried to move the `'input` lifetime from the trait to the callbacks themselves, but I still ran into https://github.com/rust-lang/rust/issues/41078 when trying to pass closures to `new_with_broken_link_callback`. I guess it's fine as is.

Breaking change, so I created a new release branch.