### PR TITLE
Replace U+0000 with U+FFFD

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2836,3 +2836,16 @@ Link refdef split from paragraph with line with spaces.
 .
 <p>:</p>
 ````````````````````````````````
+
+U+0000 must be replaced with U+FFFD: https://spec.commonmark.org/0.31.2/#insecure-characters
+See https://github.com/pulldown-cmark/pulldown-cmark/issues/1065
+
+```````````````````````````````` example
+ 
+   
+hello world
+.
+<p>�
+���
+hello�world</p>
+````````````````````````````````

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -1314,6 +1314,19 @@ impl<'a, 'b> FirstPass<'a, 'b> {
 
                     LoopInstruction::ContinueAndSkip(0)
                 }
+                b'\0' => {
+                    // U+0000 must be replaced with U+FFFD
+                    // https://spec.commonmark.org/0.31.2/#insecure-characters
+                    self.tree.append_text(begin_text, ix, backslash_escaped);
+                    backslash_escaped = false;
+                    self.tree.append(Item {
+                        start: ix,
+                        end: ix + 1,
+                        body: ItemBody::SynthesizeChar('\u{fffd}'),
+                    });
+                    begin_text = ix + 1;
+                    LoopInstruction::ContinueAndSkip(0)
+                }
                 _ => LoopInstruction::ContinueAndSkip(0),
             }
         });
@@ -2479,7 +2492,7 @@ fn create_lut(options: &Options) -> LookupTable {
 fn special_bytes(options: &Options) -> [bool; 256] {
     let mut bytes = [false; 256];
     let standard_bytes = [
-        b'\n', b'\r', b'*', b'_', b'&', b'\\', b'[', b']', b'<', b'!', b'`',
+        b'\n', b'\r', b'*', b'_', b'&', b'\\', b'[', b']', b'<', b'!', b'`', b'\0',
     ];
 
     for &byte in &standard_bytes {
@@ -2528,7 +2541,7 @@ type LookupTable = [bool; 256];
 
 /// This function walks the byte slices from the given index and
 /// calls the callback function on all bytes (and their indices) that are in the following set:
-/// `` ` ``, `\`, `&`, `*`, `_`, `~`, `!`, `<`, `[`, `]`, `|`, `\r`, `\n`
+/// `` ` ``, `\`, `&`, `*`, `_`, `~`, `!`, `<`, `[`, `]`, `|`, `\r`, `\n`, `\0`
 /// It is guaranteed not call the callback on other bytes.
 /// Whenever `callback(ix, byte)` returns a `ContinueAndSkip(n)` value, the callback
 /// will not be called with an index that is less than `ix + n + 1`.
@@ -2725,7 +2738,7 @@ mod simd {
     pub(super) fn compute_lookup(options: &Options) -> [u8; 16] {
         let mut lookup = [0u8; 16];
         let standard_bytes = [
-            b'\n', b'\r', b'*', b'_', b'&', b'\\', b'[', b']', b'<', b'!', b'`',
+            b'\n', b'\r', b'*', b'_', b'&', b'\\', b'[', b']', b'<', b'!', b'`', b'\0',
         ];
 
         for &byte in &standard_bytes {
@@ -2943,7 +2956,7 @@ mod simd {
         fn exhaustive_search() {
             let chars = [
                 b'\n', b'\r', b'*', b'_', b'~', b'^', b'|', b'&', b'\\', b'[', b']', b'<', b'!',
-                b'`', b'$', b'{', b'}',
+                b'`', b'$', b'{', b'}', b'\0',
             ];
 
             for &c in &chars {

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3379,3 +3379,17 @@ fn regression_test_211() {
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
 }
+
+#[test]
+fn regression_test_212() {
+    let original = r##" 
+   
+hello world
+"##;
+    let expected = r##"<p>�
+���
+hello�world</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, false, false, false);
+}


### PR DESCRIPTION
Fix #1065

With this patch the following command

```sh
echo -n "\0" | cargo run -- -e
```

outputs

```
0..1: Start(Paragraph)
0..1: Text(Inlined(InlineStr { inner: [239, 191, 189, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len: 3 }))
0..1: End(Paragraph)
EOF
```

`239 191 189` is `0xEF 0xBF 0xBD` that is UTF-8 encoded form of U+FFFD.