### PR TITLE
reword BlockQuoteKind -> AdmonitionKind, render as div

### DIFF
--- a/guide/src/dev/block-parsing.md
+++ b/guide/src/dev/block-parsing.md
@@ -20,6 +20,7 @@ The main block types handled by the first pass are:
 
 - Container blocks:
   - Block quotes
+    - Admonitions (using block quote syntax + tags)
   - Lists (ordered and unordered)  
   - List items
   - Footnote definitions

--- a/pulldown-cmark/specs/blockquotes_tags.txt
+++ b/pulldown-cmark/specs/blockquotes_tags.txt
@@ -20,54 +20,54 @@ Using one of these tags adds a class with the same name but in lowercase
 
 ```````````````````````````````` example
 > [!NOTE]
-> Note blockquote
+> Note admonition
 .
-<blockquote class="markdown-alert-note"><p>Note blockquote</p></blockquote>
+<div role="note" class="markdown-alert-note"><p>Note admonition</p></div>
 ````````````````````````````````
 
 ```````````````````````````````` example
 > [!TIP]
-> Tip blockquote
+> Tip admonition
 .
-<blockquote class="markdown-alert-tip"><p>Tip blockquote</p></blockquote>
+<div role="note" class="markdown-alert-tip"><p>Tip admonition</p></div>
 ````````````````````````````````
 
 ```````````````````````````````` example
 > [!IMPORTANT]
-> Important blockquote
+> Important admonition
 .
-<blockquote class="markdown-alert-important"><p>Important blockquote</p></blockquote>
+<div role="note" class="markdown-alert-important"><p>Important admonition</p></div>
 ````````````````````````````````
 
 ```````````````````````````````` example
 > [!WARNING]
-> Warning blockquote
+> Warning admonition
 .
-<blockquote class="markdown-alert-warning"><p>Warning blockquote</p></blockquote>
+<div role="note" class="markdown-alert-warning"><p>Warning admonition</p></div>
 ````````````````````````````````
 
 ```````````````````````````````` example
 > [!CAUTION]
-> Caution blockquote
+> Caution admonition
 .
-<blockquote class="markdown-alert-caution"><p>Caution blockquote</p></blockquote>
+<div role="note" class="markdown-alert-caution"><p>Caution admonition</p></div>
 ````````````````````````````````
 
 A blockquote with tag can be empty:
 ```````````````````````````````` example
 > [!CAUTION]
 .
-<blockquote class="markdown-alert-caution"></blockquote>
+<div role="note" class="markdown-alert-caution"></div>
 ````````````````````````````````
 
-An a blockquote can have several lines:
+An admonition can have several lines:
 ```````````````````````````````` example
 > [!CAUTION]
 > Line 1.
 > Line 2.
 .
-<blockquote class="markdown-alert-caution"><p>Line 1.
-Line 2.</p></blockquote>
+<div role="note" class="markdown-alert-caution"><p>Line 1.
+Line 2.</p></div>
 ````````````````````````````````
 
 Tags are ignored in subsequent lines, literally written:
@@ -77,9 +77,9 @@ Tags are ignored in subsequent lines, literally written:
 > [!CAUTION]
 > Line 2.
 .
-<blockquote class="markdown-alert-caution"><p>Line 1.
+<div role="note" class="markdown-alert-caution"><p>Line 1.
 [!CAUTION]
-Line 2.</p></blockquote>
+Line 2.</p></div>
 ````````````````````````````````
 
 But nested blockquotes can have their own tag:
@@ -89,7 +89,7 @@ But nested blockquotes can have their own tag:
 > > [!TIP]
 > Line 2.
 .
-<blockquote class="markdown-alert-caution"><p>Line 1.</p><blockquote class="markdown-alert-tip"><p>Line 2.</p></blockquote></blockquote>
+<div role="note" class="markdown-alert-caution"><p>Line 1.</p><div role="note" class="markdown-alert-tip"><p>Line 2.</p></div></div>
 ````````````````````````````````
 
 And consecutive blockquotes too:
@@ -101,7 +101,7 @@ And consecutive blockquotes too:
 > [!TIP]
 > Line 2.
 .
-<blockquote class="markdown-alert-caution"><p>Line 1.</p></blockquote><blockquote class="markdown-alert-tip"><p>Line 2.</p></blockquote>
+<div role="note" class="markdown-alert-caution"><p>Line 1.</p></div><div role="note" class="markdown-alert-tip"><p>Line 2.</p></div>
 ````````````````````````````````
 
 Tags also work in inner blockquotes:
@@ -110,8 +110,8 @@ Tags also work in inner blockquotes:
 > > Line 1.
 > Line 2.
 .
-<blockquote><blockquote class="markdown-alert-caution"><p>Line 1.
-Line 2.</p></blockquote></blockquote>
+<blockquote><div role="note" class="markdown-alert-caution"><p>Line 1.
+Line 2.</p></div></blockquote>
 ````````````````````````````````
 
 Tags can be followed by spaces (works in most implementations):
@@ -121,9 +121,9 @@ Tags can be followed by spaces (works in most implementations):
 > > [!NOTE]      
 > > Line 2.
 .
-<blockquote class="markdown-alert-caution"><p>Line 1.</p>
-<blockquote class="markdown-alert-note"><p>Line 2.</p></blockquote>
-</blockquote>
+<div role="note" class="markdown-alert-caution"><p>Line 1.</p>
+<div role="note" class="markdown-alert-note"><p>Line 2.</p></div>
+</div>
 ````````````````````````````````
 
 Tags are case-insensitive (works in most implementations):
@@ -133,9 +133,9 @@ Tags are case-insensitive (works in most implementations):
 > > [!note]      
 > > Line 2.
 .
-<blockquote class="markdown-alert-caution"><p>Line 1.</p>
-<blockquote class="markdown-alert-note"><p>Line 2.</p></blockquote>
-</blockquote>
+<div role="note" class="markdown-alert-caution"><p>Line 1.</p>
+<div role="note" class="markdown-alert-note"><p>Line 2.</p></div>
+</div>
 ````````````````````````````````
 
 Tags work inside lists (doesn't work in GitHub, but works elsewhere):
@@ -146,7 +146,7 @@ Tags work inside lists (doesn't work in GitHub, but works elsewhere):
     > sink ships
 .
 <ul><li><p>loose lists</p>
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
 </li></ul>
 ````````````````````````````````
 
@@ -166,11 +166,11 @@ sink ships
     > [!NOTE]
     > sink ships
 .
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
 <ul><li><p>loose lists</p>
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
 </li></ul>
 ````````````````````````````````
 
@@ -185,10 +185,10 @@ Like lazy continuations, the blockquote marker is still needed to make nested bl
     > - sink ships
 .
 <ul><li><p>loose lists</p>
-<blockquote class="markdown-alert-note"></blockquote>
+<div role="note" class="markdown-alert-note"></div>
 <ul><li>sink ships</li></ul>
-<blockquote class="markdown-alert-note">
-<ul><li>sink ships</li></ul></blockquote>
+<div role="note" class="markdown-alert-note">
+<ul><li>sink ships</li></ul></div>
 </li></ul>
 ````````````````````````````````
 

--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2577,11 +2577,11 @@ ISSUE #907
 > [!Note]
 > - Foo
 .
-<blockquote class="markdown-alert-note">
+<div role="note" class="markdown-alert-note">
 <ul>
 <li>Foo</li>
 </ul>
-</blockquote>
+</div>
 ````````````````````````````````
 
 ISSUE #912

--- a/pulldown-cmark/src/html.rs
+++ b/pulldown-cmark/src/html.rs
@@ -32,7 +32,7 @@ use pulldown_cmark_escape::{escape_href, escape_html, escape_html_body_text, Fmt
 
 use crate::{
     strings::CowStr,
-    Alignment, BlockQuoteKind, CodeBlockKind,
+    AdmonitionKind, Alignment, CodeBlockKind,
     ContainerKind::*,
     Event::{self, *},
     LinkType, Tag, TagEnd,
@@ -244,23 +244,33 @@ where
                     _ => self.write(">"),
                 }
             }
-            Tag::BlockQuote(kind) => {
-                let class_str = match kind {
-                    None => "",
-                    Some(kind) => match kind {
-                        BlockQuoteKind::Note => " class=\"markdown-alert-note\"",
-                        BlockQuoteKind::Tip => " class=\"markdown-alert-tip\"",
-                        BlockQuoteKind::Important => " class=\"markdown-alert-important\"",
-                        BlockQuoteKind::Warning => " class=\"markdown-alert-warning\"",
-                        BlockQuoteKind::Caution => " class=\"markdown-alert-caution\"",
-                    },
-                };
-                if self.end_newline {
-                    self.write(&format!("<blockquote{}>\n", class_str))
-                } else {
-                    self.write(&format!("\n<blockquote{}>\n", class_str))
+            Tag::BlockQuote(kind) => match kind {
+                None => {
+                    if self.end_newline {
+                        self.write("<blockquote>\n")
+                    } else {
+                        self.write("\n<blockquote>\n")
+                    }
                 }
-            }
+                Some(kind) => {
+                    let suffix = match kind {
+                        AdmonitionKind::Note => "note",
+                        AdmonitionKind::Tip => "tip",
+                        AdmonitionKind::Important => "important",
+                        AdmonitionKind::Warning => "warning",
+                        AdmonitionKind::Caution => "caution",
+                    };
+                    if self.end_newline {
+                        self.write(&format!(
+                            "<div role=\"note\" class=\"markdown-alert-{suffix}\">\n"
+                        ))
+                    } else {
+                        self.write(&format!(
+                            "\n<div role=\"note\" class=\"markdown-alert-{suffix}\">\n"
+                        ))
+                    }
+                }
+            },
             Tag::CodeBlock(info) => {
                 if !self.end_newline {
                     self.write_newline()?;
@@ -451,9 +461,10 @@ where
                 }
                 self.table_cell_index += 1;
             }
-            TagEnd::BlockQuote(_) => {
-                self.write("</blockquote>\n")?;
-            }
+            TagEnd::BlockQuote(kind) => match kind {
+                Some(_admonition_kind) => self.write("</div>\n")?,
+                None => self.write("</blockquote>\n")?,
+            },
             TagEnd::CodeBlock => {
                 self.write("</code></pre>\n")?;
             }

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -151,7 +151,7 @@ impl<'a> CodeBlockKind<'a> {
 /// BlockQuote kind (Note, Tip, Important, Warning, Caution).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum BlockQuoteKind {
+pub enum AdmonitionKind {
     Note,
     Tip,
     Important,
@@ -196,17 +196,20 @@ pub enum Tag<'a> {
         attrs: Vec<(CowStr<'a>, Option<CowStr<'a>>)>,
     },
 
-    /// A block quote.
+    /// A block quote or admonition.
     ///
-    /// The `BlockQuoteKind` is only parsed & populated with [`Options::ENABLE_GFM`], `None` otherwise.
+    /// Block quotes share the same notation as admonitions.
+    /// Admonitions were added to GFM in 2025, but not to the spec.
+    /// See <https://github.com/orgs/community/discussions/16925>.
+    /// The `AdmonitionKind` is only parsed & populated with [`Options::ENABLE_GFM`], `None` otherwise.
     ///
     /// ```markdown
     /// > regular quote
     ///
     /// > [!NOTE]
-    /// > note quote
+    /// > note admonition
     /// ```
-    BlockQuote(Option<BlockQuoteKind>),
+    BlockQuote(Option<AdmonitionKind>),
     /// A code block.
     CodeBlock(CodeBlockKind<'a>),
     ContainerBlock(ContainerKind, CowStr<'a>),
@@ -415,7 +418,7 @@ pub enum TagEnd {
     Paragraph,
     Heading(HeadingLevel),
 
-    BlockQuote(Option<BlockQuoteKind>),
+    BlockQuote(Option<AdmonitionKind>),
     CodeBlock,
     ContainerBlock(ContainerKind),
 

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -40,7 +40,7 @@ use crate::{
     scanners::*,
     strings::CowStr,
     tree::{Tree, TreeIndex},
-    Alignment, BlockQuoteKind, CodeBlockKind, ContainerKind, Event, HeadingLevel, LinkType,
+    AdmonitionKind, Alignment, CodeBlockKind, ContainerKind, Event, HeadingLevel, LinkType,
     MetadataBlockKind, Options, Tag, TagEnd,
 };
 
@@ -113,7 +113,7 @@ pub(crate) enum ItemBody {
     FencedCodeBlock(CowIndex),
     IndentCodeBlock,
     HtmlBlock,
-    BlockQuote(Option<BlockQuoteKind>),
+    BlockQuote(Option<AdmonitionKind>),
     Container(u8, ContainerKind, CowIndex), // (fence length, specific renderer, descriptor used in renderer)
     List(bool, u8, u64),                    // is_tight, list character, list start index
     ListItem(usize),                        // indent level

--- a/pulldown-cmark/src/scanners.rs
+++ b/pulldown-cmark/src/scanners.rs
@@ -27,7 +27,7 @@ use memchr::memchr;
 
 pub(crate) use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 use crate::{
-    entities, parse::HtmlScanGuard, strings::CowStr, Alignment, BlockQuoteKind, HeadingLevel,
+    entities, parse::HtmlScanGuard, strings::CowStr, AdmonitionKind, Alignment, HeadingLevel,
     LinkType,
 };
 
@@ -225,19 +225,19 @@ impl<'a> LineStart<'a> {
         ok
     }
 
-    pub(crate) fn scan_blockquote_tag(&mut self) -> Option<BlockQuoteKind> {
+    pub(crate) fn scan_blockquote_tag(&mut self) -> Option<AdmonitionKind> {
         let saved_ix = self.ix;
         let tag = if self.scan_ch(b'[') && self.scan_ch(b'!') {
             let tag = if self.scan_case_insensitive(b"note") {
-                Some(BlockQuoteKind::Note)
+                Some(AdmonitionKind::Note)
             } else if self.scan_case_insensitive(b"tip") {
-                Some(BlockQuoteKind::Tip)
+                Some(AdmonitionKind::Tip)
             } else if self.scan_case_insensitive(b"important") {
-                Some(BlockQuoteKind::Important)
+                Some(AdmonitionKind::Important)
             } else if self.scan_case_insensitive(b"warning") {
-                Some(BlockQuoteKind::Warning)
+                Some(AdmonitionKind::Warning)
             } else if self.scan_case_insensitive(b"caution") {
-                Some(BlockQuoteKind::Caution)
+                Some(AdmonitionKind::Caution)
             } else {
                 None
             };

--- a/pulldown-cmark/tests/suite/blockquotes_tags.rs
+++ b/pulldown-cmark/tests/suite/blockquotes_tags.rs
@@ -16,9 +16,9 @@ fn blockquotes_tags_test_1() {
 #[test]
 fn blockquotes_tags_test_2() {
     let original = r##"> [!NOTE]
-> Note blockquote
+> Note admonition
 "##;
-    let expected = r##"<blockquote class="markdown-alert-note"><p>Note blockquote</p></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-note"><p>Note admonition</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -27,9 +27,9 @@ fn blockquotes_tags_test_2() {
 #[test]
 fn blockquotes_tags_test_3() {
     let original = r##"> [!TIP]
-> Tip blockquote
+> Tip admonition
 "##;
-    let expected = r##"<blockquote class="markdown-alert-tip"><p>Tip blockquote</p></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-tip"><p>Tip admonition</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -38,9 +38,9 @@ fn blockquotes_tags_test_3() {
 #[test]
 fn blockquotes_tags_test_4() {
     let original = r##"> [!IMPORTANT]
-> Important blockquote
+> Important admonition
 "##;
-    let expected = r##"<blockquote class="markdown-alert-important"><p>Important blockquote</p></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-important"><p>Important admonition</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -49,9 +49,9 @@ fn blockquotes_tags_test_4() {
 #[test]
 fn blockquotes_tags_test_5() {
     let original = r##"> [!WARNING]
-> Warning blockquote
+> Warning admonition
 "##;
-    let expected = r##"<blockquote class="markdown-alert-warning"><p>Warning blockquote</p></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-warning"><p>Warning admonition</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -60,9 +60,9 @@ fn blockquotes_tags_test_5() {
 #[test]
 fn blockquotes_tags_test_6() {
     let original = r##"> [!CAUTION]
-> Caution blockquote
+> Caution admonition
 "##;
-    let expected = r##"<blockquote class="markdown-alert-caution"><p>Caution blockquote</p></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-caution"><p>Caution admonition</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -72,7 +72,7 @@ fn blockquotes_tags_test_6() {
 fn blockquotes_tags_test_7() {
     let original = r##"> [!CAUTION]
 "##;
-    let expected = r##"<blockquote class="markdown-alert-caution"></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-caution"></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -84,8 +84,8 @@ fn blockquotes_tags_test_8() {
 > Line 1.
 > Line 2.
 "##;
-    let expected = r##"<blockquote class="markdown-alert-caution"><p>Line 1.
-Line 2.</p></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-caution"><p>Line 1.
+Line 2.</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -98,9 +98,9 @@ fn blockquotes_tags_test_9() {
 > [!CAUTION]
 > Line 2.
 "##;
-    let expected = r##"<blockquote class="markdown-alert-caution"><p>Line 1.
+    let expected = r##"<div role="note" class="markdown-alert-caution"><p>Line 1.
 [!CAUTION]
-Line 2.</p></blockquote>
+Line 2.</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -113,7 +113,7 @@ fn blockquotes_tags_test_10() {
 > > [!TIP]
 > Line 2.
 "##;
-    let expected = r##"<blockquote class="markdown-alert-caution"><p>Line 1.</p><blockquote class="markdown-alert-tip"><p>Line 2.</p></blockquote></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-caution"><p>Line 1.</p><div role="note" class="markdown-alert-tip"><p>Line 2.</p></div></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -128,7 +128,7 @@ fn blockquotes_tags_test_11() {
 > [!TIP]
 > Line 2.
 "##;
-    let expected = r##"<blockquote class="markdown-alert-caution"><p>Line 1.</p></blockquote><blockquote class="markdown-alert-tip"><p>Line 2.</p></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-caution"><p>Line 1.</p></div><div role="note" class="markdown-alert-tip"><p>Line 2.</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -140,8 +140,8 @@ fn blockquotes_tags_test_12() {
 > > Line 1.
 > Line 2.
 "##;
-    let expected = r##"<blockquote><blockquote class="markdown-alert-caution"><p>Line 1.
-Line 2.</p></blockquote></blockquote>
+    let expected = r##"<blockquote><div role="note" class="markdown-alert-caution"><p>Line 1.
+Line 2.</p></div></blockquote>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -154,9 +154,9 @@ fn blockquotes_tags_test_13() {
 > > [!NOTE]      
 > > Line 2.
 "##;
-    let expected = r##"<blockquote class="markdown-alert-caution"><p>Line 1.</p>
-<blockquote class="markdown-alert-note"><p>Line 2.</p></blockquote>
-</blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-caution"><p>Line 1.</p>
+<div role="note" class="markdown-alert-note"><p>Line 2.</p></div>
+</div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -169,9 +169,9 @@ fn blockquotes_tags_test_14() {
 > > [!note]      
 > > Line 2.
 "##;
-    let expected = r##"<blockquote class="markdown-alert-caution"><p>Line 1.</p>
-<blockquote class="markdown-alert-note"><p>Line 2.</p></blockquote>
-</blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-caution"><p>Line 1.</p>
+<div role="note" class="markdown-alert-note"><p>Line 2.</p></div>
+</div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
@@ -185,7 +185,7 @@ fn blockquotes_tags_test_15() {
     > sink ships
 "##;
     let expected = r##"<ul><li><p>loose lists</p>
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
 </li></ul>
 "##;
 
@@ -208,11 +208,11 @@ sink ships
     > [!NOTE]
     > sink ships
 "##;
-    let expected = r##"<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
+    let expected = r##"<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
 <ul><li><p>loose lists</p>
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
-<blockquote class="markdown-alert-note"><p>sink ships</p></blockquote>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
+<div role="note" class="markdown-alert-note"><p>sink ships</p></div>
 </li></ul>
 "##;
 
@@ -230,10 +230,10 @@ fn blockquotes_tags_test_17() {
     > - sink ships
 "##;
     let expected = r##"<ul><li><p>loose lists</p>
-<blockquote class="markdown-alert-note"></blockquote>
+<div role="note" class="markdown-alert-note"></div>
 <ul><li>sink ships</li></ul>
-<blockquote class="markdown-alert-note">
-<ul><li>sink ships</li></ul></blockquote>
+<div role="note" class="markdown-alert-note">
+<ul><li>sink ships</li></ul></div>
 </li></ul>
 "##;
 

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3077,11 +3077,11 @@ fn regression_test_195() {
     let original = r##"> [!Note]
 > - Foo
 "##;
-    let expected = r##"<blockquote class="markdown-alert-note">
+    let expected = r##"<div role="note" class="markdown-alert-note">
 <ul>
 <li>Foo</li>
 </ul>
-</blockquote>
+</div>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);


### PR DESCRIPTION
The extended GFM reuses blocks that are usually for quote also for admonitions, so while the notation is ambiguous, we can distinguish the semantics. This is an API breakage for library users.

The rendering as a `<div role="note">` is semantically more adequate and more suitable for assistive tooling. There is no semantic HTML element for this purpose at this point. For reference, see
- <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/note_role>
- <https://www.w3.org/TR/WCAG21/#name-role-value>

via #1068 