### PR TITLE
feat: add opt-in CJK-friendly emphasis extension

### DIFF
--- a/pulldown-cmark/src/cjk.rs
+++ b/pulldown-cmark/src/cjk.rs
@@ -1,0 +1,202 @@
+// CJK-friendly emphasis support.
+//
+// This module implements character classification functions for the
+// CommonMark CJK-friendly amendments specification:
+// https://github.com/tats-u/markdown-cjk-friendly/blob/main/specification.md
+//
+// The key insight is that CJK punctuation (e.g. 「」、。！？（）) should not
+// block delimiter flanking detection the way ASCII punctuation does, because
+// CJK languages do not use spaces between words and punctuation.
+
+use crate::puncttable::is_punctuation;
+
+/// Returns true if `c` is a CJK character as defined by the CJK-friendly
+/// amendments specification.
+///
+/// A CJK character has East Asian Width W (Wide), F (Fullwidth), or H (Halfwidth)
+/// and is not a default emoji presentation character, OR has Unicode Script = Hangul.
+///
+/// The ranges are derived from Unicode 16.0 / markdown-cjk-friendly ranges.md.
+pub(crate) fn is_cjk_character(c: char) -> bool {
+    let cp = c as u32;
+    matches!(cp,
+        // Hangul Jamo
+        0x1100..=0x11FF |
+        // CJK Radicals Supplement, Kangxi Radicals
+        0x2E80..=0x2FDF |
+        // Ideographic Description Characters, CJK Symbols and Punctuation
+        0x2FF0..=0x303F |
+        // Hiragana
+        0x3041..=0x3096 |
+        0x3099..=0x309F |
+        // Katakana
+        0x30A0..=0x30FF |
+        // Bopomofo
+        0x3105..=0x312F |
+        // Hangul Compatibility Jamo
+        0x3131..=0x318E |
+        // Kanbun, Bopomofo Extended
+        0x3190..=0x31BF |
+        // CJK Strokes
+        0x31C0..=0x31EF |
+        // Katakana Phonetic Extensions
+        0x31F0..=0x31FF |
+        // Enclosed CJK Letters and Months
+        0x3200..=0x32FF |
+        // CJK Compatibility
+        0x3300..=0x33FF |
+        // CJK Unified Ideographs Extension A
+        0x3400..=0x4DBF |
+        // CJK Unified Ideographs
+        0x4E00..=0x9FFF |
+        // Yi Syllables, Yi Radicals
+        0xA000..=0xA4CF |
+        // Hangul Jamo Extended-A
+        0xA960..=0xA97F |
+        // Hangul Syllables
+        0xAC00..=0xD7A3 |
+        // Hangul Jamo Extended-B
+        0xD7B0..=0xD7FF |
+        // CJK Compatibility Ideographs
+        0xF900..=0xFAFF |
+        // CJK Compatibility Forms, Small Form Variants
+        0xFE30..=0xFE6F |
+        // Halfwidth and Fullwidth Forms
+        0xFF01..=0xFF60 |
+        0xFFE0..=0xFFE6 |
+        // Halfwidth Katakana
+        0xFF65..=0xFF9F |
+        // Halfwidth Hangul
+        0xFFA0..=0xFFDC |
+        // Halfwidth symbols
+        0xFFE8..=0xFFEE |
+        // Kana Extended-B, Kana Supplement, Kana Extended-A, Small Kana Extension
+        0x1AFF0..=0x1B16F |
+        // CJK Unified Ideographs Extension B
+        0x20000..=0x2A6DF |
+        // CJK Unified Ideographs Extension C
+        0x2A700..=0x2B73F |
+        // CJK Unified Ideographs Extension D
+        0x2B740..=0x2B81F |
+        // CJK Unified Ideographs Extension E
+        0x2B820..=0x2CEAF |
+        // CJK Unified Ideographs Extension F
+        0x2CEB0..=0x2EBEF |
+        // CJK Unified Ideographs Extension I
+        0x2EBF0..=0x2F7FF |
+        // CJK Compatibility Ideographs Supplement
+        0x2F800..=0x2FA1F |
+        // CJK Unified Ideographs Extension G
+        0x30000..=0x3134F |
+        // CJK Unified Ideographs Extension H
+        0x31350..=0x323AF
+    )
+}
+
+/// Returns true if `c` is a punctuation character that is NOT a CJK character.
+///
+/// In the CJK-friendly amendments, the distinction between CJK punctuation
+/// and non-CJK punctuation is crucial: CJK punctuation should not prevent
+/// delimiter runs from being flanking.
+pub(crate) fn is_non_cjk_punctuation(c: char) -> bool {
+    is_punctuation(c) && !is_cjk_character(c)
+}
+
+/// Returns true if `c` is a non-emoji general-use variation selector (U+FE00..U+FE0E).
+///
+/// These selectors can appear between a CJK character and a delimiter.
+/// When checking the character before a delimiter, we need to "see through"
+/// these selectors to find the actual preceding character.
+///
+/// Note: U+FE0F (Emoji Presentation Selector) is excluded.
+pub(crate) fn is_general_variation_selector(c: char) -> bool {
+    ('\u{FE00}'..='\u{FE0E}').contains(&c)
+}
+
+/// Returns true if `c` is an Ideographic Variation Selector (U+E0100..U+E01EF).
+///
+/// An IVS before a delimiter run means the preceding character is a CJK ideograph.
+pub(crate) fn is_ideographic_variation_selector(c: char) -> bool {
+    ('\u{E0100}'..='\u{E01EF}').contains(&c)
+}
+
+/// Look through variation selectors to find the "real" preceding character
+/// and the character before that.
+///
+/// Returns (prev_char, prev_prev_char) after skipping variation selectors.
+pub(crate) fn previous_chars_skip_vs(s: &str, ix: usize) -> (Option<char>, Option<char>) {
+    let mut iter = s[..ix].chars().rev();
+    // Skip variation selectors
+    let mut prev = iter.next();
+    while prev.is_some_and(|c| is_general_variation_selector(c) || is_ideographic_variation_selector(c)) {
+        prev = iter.next();
+    }
+    let prev_prev = iter.next();
+    (prev, prev_prev)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cjk_characters() {
+        // Hiragana
+        assert!(is_cjk_character('あ'));
+        assert!(is_cjk_character('ん'));
+        // Katakana
+        assert!(is_cjk_character('ア'));
+        assert!(is_cjk_character('ン'));
+        // CJK Unified Ideographs
+        assert!(is_cjk_character('漢'));
+        assert!(is_cjk_character('字'));
+        // Hangul
+        assert!(is_cjk_character('한'));
+        assert!(is_cjk_character('글'));
+        // CJK punctuation
+        assert!(is_cjk_character('「'));
+        assert!(is_cjk_character('」'));
+        assert!(is_cjk_character('。'));
+        assert!(is_cjk_character('、'));
+        // Fullwidth forms
+        assert!(is_cjk_character('！'));
+        assert!(is_cjk_character('？'));
+        assert!(is_cjk_character('（'));
+        assert!(is_cjk_character('）'));
+        // Non-CJK
+        assert!(!is_cjk_character('a'));
+        assert!(!is_cjk_character('Z'));
+        assert!(!is_cjk_character('.'));
+        assert!(!is_cjk_character('!'));
+        assert!(!is_cjk_character(' '));
+    }
+
+    #[test]
+    fn test_non_cjk_punctuation() {
+        // ASCII punctuation is non-CJK punctuation
+        assert!(is_non_cjk_punctuation('.'));
+        assert!(is_non_cjk_punctuation('!'));
+        assert!(is_non_cjk_punctuation('('));
+        assert!(is_non_cjk_punctuation(')'));
+        // CJK punctuation is NOT non-CJK punctuation
+        assert!(!is_non_cjk_punctuation('。'));
+        assert!(!is_non_cjk_punctuation('、'));
+        assert!(!is_non_cjk_punctuation('「'));
+        assert!(!is_non_cjk_punctuation('」'));
+        assert!(!is_non_cjk_punctuation('！'));
+        assert!(!is_non_cjk_punctuation('？'));
+        // Regular letters are not punctuation at all
+        assert!(!is_non_cjk_punctuation('a'));
+        assert!(!is_non_cjk_punctuation('漢'));
+    }
+
+    #[test]
+    fn test_variation_selectors() {
+        assert!(is_general_variation_selector('\u{FE00}'));
+        assert!(is_general_variation_selector('\u{FE0E}'));
+        assert!(!is_general_variation_selector('\u{FE0F}')); // emoji presentation selector excluded
+        assert!(is_ideographic_variation_selector('\u{E0100}'));
+        assert!(is_ideographic_variation_selector('\u{E01EF}'));
+        assert!(!is_ideographic_variation_selector('\u{E01F0}'));
+    }
+}

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -7,6 +7,7 @@ use core::{cmp::max, ops::Range, u8};
 use unicase::UniCase;
 
 use crate::{
+    cjk::{is_cjk_character, is_non_cjk_punctuation, previous_chars_skip_vs},
     linklabel::{scan_link_label_rest, LinkLabel},
     parse::{
         scan_containers, Allocations, FootnoteDef, HeadingAttributes, Item, ItemBody, LinkDef,
@@ -2378,6 +2379,7 @@ fn delim_run_can_open(
     mode: TableParseMode,
     options: Options,
 ) -> bool {
+    let cjk_mode = options.contains(Options::ENABLE_CJK_FRIENDLY_EMPHASIS);
     let next_char = if let Some(c) = suffix[run_len..].chars().next() {
         c
     } else {
@@ -2417,8 +2419,16 @@ fn delim_run_can_open(
             return false;
         }
     }
+
+    // In CJK mode, use non-CJK punctuation for flanking checks
+    let next_is_punct = if cjk_mode {
+        is_non_cjk_punctuation(next_char)
+    } else {
+        is_punctuation(next_char)
+    };
+
     // `*`, `~~`, and `^` can be intraword, `~` can only be interword if it's subscript, `_` cannot
-    if delim == b'*' && !is_punctuation(next_char) {
+    if delim == b'*' && !next_is_punct {
         return true;
     }
     // `^` with non-punctuation content can open intraword
@@ -2428,16 +2438,30 @@ fn delim_run_can_open(
     if delim == b'~' && run_len > 1 {
         return true;
     }
-    let prev_char = s[..ix].chars().last().unwrap();
+
+    let (prev_char_raw, _) = if cjk_mode {
+        previous_chars_skip_vs(s, ix)
+    } else {
+        (s[..ix].chars().last(), None)
+    };
+    let prev_char = prev_char_raw.unwrap();
+
     if delim == b'~'
         && (prev_char == '~' || options.contains(Options::ENABLE_SUBSCRIPT))
-        && !is_punctuation(next_char)
+        && !next_is_punct
     {
         return true;
     }
 
+    let prev_is_punct = if cjk_mode {
+        is_non_cjk_punctuation(prev_char)
+    } else {
+        is_punctuation(prev_char)
+    };
+
     prev_char.is_whitespace()
-        || is_punctuation(prev_char) && (delim != b'\'' || ![']', ')'].contains(&prev_char))
+        || prev_is_punct && (delim != b'\'' || ![']', ')'].contains(&prev_char))
+        || (cjk_mode && is_cjk_character(prev_char))
 }
 
 /// Determines whether the delimiter run starting at given index is
@@ -2451,10 +2475,18 @@ fn delim_run_can_close(
     mode: TableParseMode,
     options: Options,
 ) -> bool {
+    let cjk_mode = options.contains(Options::ENABLE_CJK_FRIENDLY_EMPHASIS);
     if ix == 0 {
         return false;
     }
-    let prev_char = s[..ix].chars().last().unwrap();
+
+    let (prev_char_raw, _) = if cjk_mode {
+        previous_chars_skip_vs(s, ix)
+    } else {
+        (s[..ix].chars().last(), None)
+    };
+    let prev_char = prev_char_raw.unwrap();
+
     if prev_char.is_whitespace() {
         return false;
     }
@@ -2472,18 +2504,32 @@ fn delim_run_can_close(
         }
     }
     let delim = suffix.bytes().next().unwrap();
+
+    // In CJK mode, use non-CJK punctuation for flanking checks
+    let prev_is_punct = if cjk_mode {
+        is_non_cjk_punctuation(prev_char)
+    } else {
+        is_punctuation(prev_char)
+    };
+
     // `*`, `~~`, and `^` can be intraword, `~` can only be interword if it's subscript, `_` cannot
-    if (delim == b'*' || (delim == b'~' && run_len > 1)) && !is_punctuation(prev_char) {
+    if (delim == b'*' || (delim == b'~' && run_len > 1)) && !prev_is_punct {
         return true;
     }
-    if delim == b'^' && !is_punctuation(prev_char) {
+    if delim == b'^' && !prev_is_punct {
         return true;
     }
     if delim == b'~' && (prev_char == '~' || options.contains(Options::ENABLE_SUBSCRIPT)) {
         return true;
     }
 
-    next_char.is_whitespace() || is_punctuation(next_char)
+    let next_is_punct = if cjk_mode {
+        is_non_cjk_punctuation(next_char)
+    } else {
+        is_punctuation(next_char)
+    };
+
+    next_char.is_whitespace() || next_is_punct || (cjk_mode && is_cjk_character(next_char))
 }
 
 fn create_lut(options: &Options) -> LookupTable {

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -101,6 +101,7 @@ pub mod html;
 
 pub mod utils;
 
+mod cjk;
 mod entities;
 mod firstpass;
 mod linklabel;
@@ -768,6 +769,16 @@ bitflags::bitflags! {
         const ENABLE_WIKILINKS = 1 << 15;
         /// Colon-delimited Container Extension Blocks.
         const ENABLE_CONTAINER_EXTENSIONS = 1 << 16;
+        /// CJK-friendly emphasis heuristics.
+        ///
+        /// When enabled, delimiter run detection distinguishes CJK punctuation
+        /// (e.g. `「」、。！？（）`) from non-CJK punctuation, allowing emphasis
+        /// to work correctly adjacent to CJK text without surrounding whitespace.
+        ///
+        /// This implements the [CommonMark CJK-friendly amendments](https://github.com/tats-u/markdown-cjk-friendly/blob/main/specification.md).
+        ///
+        /// Default behavior (when disabled) is unchanged from standard CommonMark.
+        const ENABLE_CJK_FRIENDLY_EMPHASIS = 1 << 17;
     }
 }
 

--- a/pulldown-cmark/tests/html.rs
+++ b/pulldown-cmark/tests/html.rs
@@ -356,3 +356,257 @@ fn issue_819() {
         assert_eq!(expected, s.trim_end_matches('\n'));
     }
 }
+
+// ============================================================
+// CJK-friendly emphasis tests
+// ============================================================
+
+/// Helper to render markdown with CJK-friendly emphasis enabled.
+fn render_cjk(input: &str) -> String {
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_CJK_FRIENDLY_EMPHASIS);
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new_ext(input, opts));
+    s
+}
+
+/// Helper to render markdown with default options (no CJK mode).
+fn render_default(input: &str) -> String {
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(input));
+    s
+}
+
+// -- Japanese quotation marks --
+
+#[test]
+fn cjk_emphasis_japanese_corner_brackets() {
+    assert_eq!(
+        render_cjk("これは**「重要」**です"),
+        "<p>これは<strong>「重要」</strong>です</p>\n"
+    );
+}
+
+#[test]
+fn cjk_emphasis_japanese_double_corner_brackets() {
+    assert_eq!(
+        render_cjk("これは**『重要』**です"),
+        "<p>これは<strong>『重要』</strong>です</p>\n"
+    );
+}
+
+#[test]
+fn cjk_emphasis_japanese_fullwidth_quotes() {
+    assert_eq!(
+        render_cjk("これは**\u{201C}重要\u{201D}**です"),
+        "<p>これは<strong>\u{201C}重要\u{201D}</strong>です</p>\n"
+    );
+}
+
+// -- Japanese parentheses and brackets --
+
+#[test]
+fn cjk_emphasis_japanese_fullwidth_parens() {
+    assert_eq!(
+        render_cjk("これは**（仮）**です"),
+        "<p>これは<strong>（仮）</strong>です</p>\n"
+    );
+}
+
+#[test]
+fn cjk_emphasis_japanese_lenticular_brackets() {
+    assert_eq!(
+        render_cjk("これは**【重要】**です"),
+        "<p>これは<strong>【重要】</strong>です</p>\n"
+    );
+}
+
+// -- CJK punctuation at end of emphasis --
+
+#[test]
+fn cjk_emphasis_period_inside() {
+    assert_eq!(
+        render_cjk("これは**重要。**だから"),
+        "<p>これは<strong>重要。</strong>だから</p>\n"
+    );
+}
+
+#[test]
+fn cjk_emphasis_comma_inside() {
+    assert_eq!(
+        render_cjk("これは**重要、**だから"),
+        "<p>これは<strong>重要、</strong>だから</p>\n"
+    );
+}
+
+#[test]
+fn cjk_emphasis_exclamation_inside() {
+    assert_eq!(
+        render_cjk("これは**重要！**だから"),
+        "<p>これは<strong>重要！</strong>だから</p>\n"
+    );
+}
+
+// -- Emphasis at start of text followed by CJK --
+
+#[test]
+fn cjk_emphasis_start_corner_brackets() {
+    assert_eq!(
+        render_cjk("**「注意」**してください"),
+        "<p><strong>「注意」</strong>してください</p>\n"
+    );
+}
+
+#[test]
+fn cjk_emphasis_start_period() {
+    assert_eq!(
+        render_cjk("**重要。**なので"),
+        "<p><strong>重要。</strong>なので</p>\n"
+    );
+}
+
+// -- Emphasis preceded by CJK --
+
+#[test]
+fn cjk_emphasis_preceded_by_cjk() {
+    assert_eq!(
+        render_cjk("彼は**「異常」**と言った"),
+        "<p>彼は<strong>「異常」</strong>と言った</p>\n"
+    );
+}
+
+#[test]
+fn cjk_emphasis_preceded_by_cjk_parens() {
+    assert_eq!(
+        render_cjk("私は**（仮説）**だと思う"),
+        "<p>私は<strong>（仮説）</strong>だと思う</p>\n"
+    );
+}
+
+// -- Chinese examples --
+
+#[test]
+fn cjk_emphasis_chinese_fullwidth_quotes() {
+    assert_eq!(
+        render_cjk("我是**\u{201C}美國人\u{201D}**。"),
+        "<p>我是<strong>\u{201C}美國人\u{201D}</strong>。</p>\n"
+    );
+}
+
+#[test]
+fn cjk_emphasis_chinese_period() {
+    assert_eq!(
+        render_cjk("这是。**强调**吗？"),
+        "<p>这是。<strong>强调</strong>吗？</p>\n"
+    );
+}
+
+// -- Korean examples --
+
+#[test]
+fn cjk_emphasis_korean_hangul() {
+    assert_eq!(
+        render_cjk("**강조**합니다"),
+        "<p><strong>강조</strong>합니다</p>\n"
+    );
+}
+
+// -- Spec example from commonmark-spec#650 --
+
+#[test]
+fn cjk_emphasis_spec_example_cat() {
+    assert_eq!(
+        render_cjk("猫は**「のどか」**という。"),
+        "<p>猫は<strong>「のどか」</strong>という。</p>\n"
+    );
+}
+
+// -- Single emphasis (italic) --
+
+#[test]
+fn cjk_emphasis_italic_corner_brackets() {
+    assert_eq!(
+        render_cjk("これは*「重要」*です"),
+        "<p>これは<em>「重要」</em>です</p>\n"
+    );
+}
+
+// -- Underscore delimiters --
+
+#[test]
+fn cjk_emphasis_underscore_with_cjk() {
+    // Underscore delimiters also work with CJK in CJK-friendly mode,
+    // because CJK characters satisfy the flanking condition.
+    assert_eq!(
+        render_cjk("これは__重要__です"),
+        "<p>これは<strong>重要</strong>です</p>\n"
+    );
+}
+
+// -- Mixed CJK and Latin --
+
+#[test]
+fn cjk_emphasis_mixed_latin() {
+    assert_eq!(
+        render_cjk("日本語**English**混在"),
+        "<p>日本語<strong>English</strong>混在</p>\n"
+    );
+}
+
+// -- Backward compatibility: default mode (no CJK flag) --
+
+#[test]
+fn cjk_default_mode_unchanged() {
+    // Without ENABLE_CJK_FRIENDLY_EMPHASIS, CJK emphasis with punctuation
+    // should NOT work (preserving backward compatibility)
+    let result = render_default("これは**「重要」**です");
+    // The emphasis should fail, resulting in literal ** in output
+    assert!(
+        result.contains("**"),
+        "Default mode should not change CJK emphasis behavior"
+    );
+}
+
+// -- Backward compatibility: non-CJK text with CJK mode --
+
+#[test]
+fn cjk_mode_ascii_quotes_unchanged() {
+    // CommonMark example 360: a*"foo"* should not be emphasis
+    assert_eq!(
+        render_cjk("a*\"foo\"*"),
+        "<p>a*\"foo\"*</p>\n"
+    );
+}
+
+#[test]
+fn cjk_mode_intraword_underscore_unchanged() {
+    // foo_bar_baz should not produce emphasis
+    assert_eq!(
+        render_cjk("foo_bar_baz"),
+        "<p>foo_bar_baz</p>\n"
+    );
+}
+
+#[test]
+fn cjk_mode_strong_emph() {
+    assert_eq!(
+        render_cjk("***strong emph***"),
+        "<p><em><strong>strong emph</strong></em></p>\n"
+    );
+}
+
+#[test]
+fn cjk_mode_basic_emphasis() {
+    assert_eq!(
+        render_cjk("This is **bold** text"),
+        "<p>This is <strong>bold</strong> text</p>\n"
+    );
+}
+
+#[test]
+fn cjk_mode_basic_italic() {
+    assert_eq!(
+        render_cjk("This is *italic* text"),
+        "<p>This is <em>italic</em> text</p>\n"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `Options::ENABLE_CJK_FRIENDLY_EMPHASIS` (bit 17) to support CJK-friendly emphasis parsing, following the [CommonMark CJK-friendly amendments specification](https://github.com/tats-u/markdown-cjk-friendly/blob/main/specification.md).

This is an **opt-in extension flag** (disabled by default) that modifies delimiter run detection to distinguish CJK punctuation from non-CJK punctuation, enabling emphasis markers to work correctly adjacent to CJK text.

## Motivation

CommonMark's emphasis rules assume whitespace separates words from punctuation, which is not true for CJK languages. Text like `これは**「重要」**です` or `**テスト。**テスト` fails to produce `<strong>` tags because characters like `「」。、！？（）` are classified as Unicode punctuation, blocking left/right-flanking delimiter detection.

This is documented in [commonmark-spec#650](https://github.com/commonmark/commonmark-spec/issues/650) and affects all CJK (Chinese, Japanese, Korean) users. It is **not** an AI-specific problem — it occurs in normal CJK writing where punctuation is used without surrounding spaces.

## Precedent

- **comrak** (Rust CommonMark renderer) merged this as an opt-in extension in 2025 ([PRs #582–#607](https://github.com/kivikakk/comrak/pull/582))
- The [`markdown-cjk-friendly`](https://github.com/tats-u/markdown-cjk-friendly) project provides a formal specification with 100% CommonMark 0.31.2 test compatibility
- Implementations exist for markdown-it, micromark, remark, and goldmark

## Changes

- **New `src/cjk.rs` module**: CJK character classification functions covering Unicode 16.0 ranges (Hangul, CJK Unified Ideographs, Hiragana, Katakana, fullwidth forms, etc.), variation selector handling, and non-CJK punctuation distinction
- **Modified `src/firstpass.rs`**: `delim_run_can_open` and `delim_run_can_close` now use `is_non_cjk_punctuation` instead of `is_punctuation` when the flag is active, and treat CJK characters as valid flanking context
- **`Options::ENABLE_CJK_FRIENDLY_EMPHASIS`** at bit position 17 in `src/lib.rs`
- **25 test cases** in `tests/html.rs` covering Japanese, Chinese, Korean text, backward compatibility, and non-CJK regression

## Key design decisions

1. **Opt-in flag, not default behavior** — matches comrak's approach; zero risk of behavioral change for existing users
2. **Zero overhead when disabled** — the CJK check is gated behind `options.contains(...)`, adding no cost to the default path
3. **Variation selector transparency** — `previous_chars_skip_vs()` uses `.chars().rev()` to look through variation selectors efficiently (avoids the O(n²) issue identified in PR #1059)
4. **CJK character ranges from the authoritative specification** — derived from `markdown-cjk-friendly/ranges.md`, covering the full set of W/F/H East Asian Width characters minus emoji

## Relation to PR #1059

This supersedes #1059, which has been inactive since November 2025 and has merge conflicts. This PR incorporates the review feedback from @ollpu (avoiding O(n²) string iteration) and adds more comprehensive test coverage (25 vs 6 test cases). Credit to @3w36zj6 for the original PR and to @tats-u for the CJK-friendly specification.

## Test plan

- [x] All 1183 CommonMark spec tests pass unchanged
- [x] All 1183 spec tests produce **identical output** with `ENABLE_CJK_FRIENDLY_EMPHASIS` enabled (no non-CJK regression)
- [x] 25 CJK-specific tests cover Japanese quotation marks (`「」『』`), parentheses (`（）【】`), periods (`。、！`), Chinese (`""`), Korean (Hangul), mixed CJK/Latin, `*`/`**`/`_`/`__` delimiters
- [x] Backward compatibility test verifies default mode is unchanged
- [x] `cargo clippy` clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)