### PR TITLE
Add tightness and marker type to `Tag::List`

### DIFF
--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -13,7 +13,7 @@ use mozjs::rooted;
 use mozjs::rust::wrappers::JS_CallFunctionName;
 use mozjs::rust::SIMPLE_GLOBAL_CLASS;
 use mozjs::rust::{JSEngine, RealmOptions, Runtime};
-use pulldown_cmark::{CodeBlockKind, Event, LinkType, Parser, Tag, TagEnd};
+use pulldown_cmark::{CodeBlockKind, Event, LinkType, ListType, Parser, Tag, TagEnd};
 use quick_xml::escape::unescape;
 use quick_xml::events::Event as XmlEvent;
 use quick_xml::reader::Reader;
@@ -173,16 +173,28 @@ pub fn xml_to_events(xml: &str) -> anyhow::Result<Vec<Event<'_>>> {
                 }
                 b"list" => {
                     let start = tag.try_get_attribute("start")?;
-                    match &start {
-                        Some(start) => events.push(Event::Start(Tag::List(Some(
-                            start.unescape_value()?.parse()?,
-                        )))),
-                        None => events.push(Event::Start(Tag::List(None))),
+                    let start = match &start {
+                        Some(start) => Some(start.unescape_value()?.parse()?),
+                        None => None,
                     };
                     let tight = match tag.try_get_attribute("tight") {
                         Ok(Some(value)) if value.unescape_value()? == "true" => true,
                         _ => false,
                     };
+                    let marker_type = match tag.try_get_attribute("delimiter") {
+                        Ok(Some(value)) => match &*value.unescape_value()? {
+                            "paren" => ListType::RightParenthesis,
+                            "period" => ListType::FullStop,
+                            s => anyhow::bail!("unexpected list delimiter {s:?}"),
+                        },
+                        // We don't otherwise receive the marker type, so default to `-`.
+                        _ => ListType::HyphenMinus,
+                    };
+                    events.push(Event::Start(Tag::List {
+                        start,
+                        tight,
+                        marker_type,
+                    }));
                     block_container_stack.push((start.is_some(), tight));
                 }
                 b"item" => events.push(Event::Start(Tag::Item)),
@@ -298,6 +310,8 @@ pub fn xml_to_events(xml: &str) -> anyhow::Result<Vec<Event<'_>>> {
 ///
 /// - Adds a final newline to non-empty `Tag::CodeBlock` tags.
 ///
+/// - Resets list type of unordered lists to `ListType::HyphenMinus`.
+///
 /// - Resets the link type to `LinkType::Inline`.
 ///
 /// - Resets all code blocks to `CodeBlockKind::Fenced`.
@@ -339,6 +353,17 @@ pub fn normalize(events: Vec<Event<'_>>) -> Vec<Event<'_>> {
     normalized
         .into_iter()
         .filter_map(|event| match event {
+            // commonmark.js does not record the list type.
+            Event::Start(Tag::List {
+                start,
+                tight,
+                marker_type,
+            }) if !marker_type.is_ordered() => Some(Event::Start(Tag::List {
+                start,
+                tight,
+                marker_type: ListType::HyphenMinus,
+            })),
+
             // commonmark.js does not record the link type.
             Event::Start(Tag::Link {
                 link_type: LinkType::Email,
@@ -451,14 +476,22 @@ mod tests {
     fn test_normalize_non_empty_list() {
         assert_eq!(
             normalize(vec![
-                Event::Start(Tag::List(None)),
+                Event::Start(Tag::List {
+                    start: None,
+                    tight: true,
+                    marker_type: ListType::Asterisk
+                }),
                 Event::Start(Tag::Item),
                 Event::Text("foo".into()),
                 Event::End(TagEnd::Item),
                 Event::End(TagEnd::List(false)),
             ]),
             vec![
-                Event::Start(Tag::List(None)),
+                Event::Start(Tag::List {
+                    start: None,
+                    tight: true,
+                    marker_type: ListType::HyphenMinus
+                }),
                 Event::Start(Tag::Item),
                 Event::Start(Tag::Paragraph),
                 Event::Text("foo".into()),
@@ -473,13 +506,21 @@ mod tests {
     fn test_normalize_empty_list() {
         assert_eq!(
             normalize(vec![
-                Event::Start(Tag::List(None)),
+                Event::Start(Tag::List {
+                    start: None,
+                    tight: true,
+                    marker_type: ListType::HyphenMinus
+                }),
                 Event::Start(Tag::Item),
                 Event::End(TagEnd::Item),
                 Event::End(TagEnd::List(false)),
             ]),
             vec![
-                Event::Start(Tag::List(None)),
+                Event::Start(Tag::List {
+                    start: None,
+                    tight: true,
+                    marker_type: ListType::HyphenMinus
+                }),
                 Event::Start(Tag::Item),
                 Event::End(TagEnd::Item),
                 Event::End(TagEnd::List(false)),

--- a/pulldown-cmark/examples/parser-map-tag-print.rs
+++ b/pulldown-cmark/examples/parser-map-tag-print.rs
@@ -56,9 +56,13 @@ fn main() {
                     level, id, classes, attrs
                 ),
                 Tag::Paragraph => println!("Paragraph"),
-                Tag::List(ordered_list_first_item_number) => println!(
-                    "List ordered_list_first_item_number: {:?}",
-                    ordered_list_first_item_number
+                Tag::List {
+                    start: ordered_list_first_item_number,
+                    tight,
+                    marker_type,
+                } => println!(
+                    "List ordered_list_first_item_number: {:?} tight: {} marker_type: {}",
+                    ordered_list_first_item_number, tight, marker_type,
                 ),
                 Tag::DefinitionList => println!("Definition list"),
                 Tag::DefinitionListTitle => println!("Definition title (definition list item)"),

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -15,7 +15,7 @@ use crate::{
     scanners::*,
     strings::CowStr,
     tree::{Tree, TreeIndex},
-    ContainerKind, HeadingLevel, MetadataBlockKind, Options,
+    ContainerKind, HeadingLevel, ListType, MetadataBlockKind, Options,
 };
 
 /// Runs the first pass, which resolves the block structure of the document,
@@ -1675,11 +1675,11 @@ impl<'a, 'b> FirstPass<'a, 'b> {
 
     /// Continue an existing list or start a new one if there's not an open
     /// list that matches.
-    fn continue_list(&mut self, start: usize, ch: u8, index: u64) {
+    fn continue_list(&mut self, start: usize, ty: ListType, index: u64) {
         self.finish_empty_list_item();
         if let Some(node_ix) = self.tree.peek_up() {
-            if let ItemBody::List(ref mut is_tight, existing_ch, _) = self.tree[node_ix].item.body {
-                if existing_ch == ch {
+            if let ItemBody::List(ref mut is_tight, existing_ty, _) = self.tree[node_ix].item.body {
+                if existing_ty == ty {
                     if self.last_line_blank {
                         *is_tight = false;
                         self.last_line_blank = false;
@@ -1693,7 +1693,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         self.tree.append(Item {
             start,
             end: 0, // will get set later
-            body: ItemBody::List(true, ch, index),
+            body: ItemBody::List(true, ty, index),
         });
         self.tree.push();
         self.last_line_blank = false;

--- a/pulldown-cmark/src/html.rs
+++ b/pulldown-cmark/src/html.rs
@@ -299,14 +299,16 @@ where
                     self.write("</summary>")
                 }
             }
-            Tag::List(Some(1)) => {
+            Tag::List { start: Some(1), .. } => {
                 if self.end_newline {
                     self.write("<ol>\n")
                 } else {
                     self.write("\n<ol>\n")
                 }
             }
-            Tag::List(Some(start)) => {
+            Tag::List {
+                start: Some(start), ..
+            } => {
                 if self.end_newline {
                     self.write("<ol start=\"")?;
                 } else {
@@ -315,7 +317,7 @@ where
                 write!(&mut self.writer, "{}", start)?;
                 self.write("\">\n")
             }
-            Tag::List(None) => {
+            Tag::List { start: None, .. } => {
                 if self.end_newline {
                     self.write("<ul>\n")
                 } else {

--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -229,9 +229,18 @@ pub enum Tag<'a> {
     /// ```
     HtmlBlock,
 
-    /// A list. If the list is ordered the field indicates the number of the first item.
-    /// Contains only list items.
-    List(Option<u64>), // TODO: add delim and tight for ast (not needed for html)
+    /// A list. Contains only list items.
+    List {
+        /// If the list is ordered, the number of the first item.
+        start: Option<u64>,
+        /// Whether the list is [tight](https://spec.commonmark.org/0.31.2/#loose) or loose.
+        tight: bool,
+        /// The type of marker used in the list: either `-`, `+`, `*`, `.`, or `)`.
+        ///
+        /// This will only be `-`, `+`, or `*` if `start` is `None`, and will only be `.` or `)` if
+        /// `start` is `Some`.
+        marker_type: ListType,
+    },
     /// A list item.
     Item,
     /// A footnote definition. The value contained is the footnote's label by which it can
@@ -324,7 +333,7 @@ impl<'a> Tag<'a> {
             Tag::CodeBlock(_) => TagEnd::CodeBlock,
             Tag::ContainerBlock(kind, _) => TagEnd::ContainerBlock(*kind),
             Tag::HtmlBlock => TagEnd::HtmlBlock,
-            Tag::List(number) => TagEnd::List(number.is_some()),
+            Tag::List { start: number, .. } => TagEnd::List(number.is_some()),
             Tag::Item => TagEnd::Item,
             Tag::FootnoteDefinition(_) => TagEnd::FootnoteDefinition,
             Tag::Table(_) => TagEnd::Table,
@@ -366,7 +375,15 @@ impl<'a> Tag<'a> {
             Tag::CodeBlock(kb) => Tag::CodeBlock(kb.into_static()),
             Tag::ContainerBlock(k, s) => Tag::ContainerBlock(k, s.into_static()),
             Tag::HtmlBlock => Tag::HtmlBlock,
-            Tag::List(v) => Tag::List(v),
+            Tag::List {
+                start,
+                tight,
+                marker_type,
+            } => Tag::List {
+                start,
+                tight,
+                marker_type,
+            },
             Tag::Item => Tag::Item,
             Tag::FootnoteDefinition(a) => Tag::FootnoteDefinition(a.into_static()),
             Tag::Table(v) => Tag::Table(v),
@@ -659,6 +676,36 @@ impl<'a> Event<'a> {
             Event::Rule => Event::Rule,
             Event::TaskListMarker(b) => Event::TaskListMarker(b),
         }
+    }
+}
+
+/// The type of markers in an ordered or unordered list, i.e. `-`, `+`, `*`, `.` or `)`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(u8)]
+pub enum ListType {
+    /// `-`. Used for unordered lists.
+    HyphenMinus = b'-',
+    /// `+`. Used for unordered lists.
+    PlusSign = b'+',
+    /// `*`. Used for unordered lists.
+    Asterisk = b'*',
+    /// `.`. Used for ordered lists (e.g. `1.`).
+    FullStop = b'.',
+    /// `)`. Used for ordered lists (e.g. `1)`).
+    RightParenthesis = b')',
+}
+
+impl ListType {
+    /// Returns whether the list type is for ordered lists.
+    pub const fn is_ordered(self) -> bool {
+        matches!(self, Self::FullStop | Self::RightParenthesis)
+    }
+}
+
+impl Display for ListType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(char::from(*self as u8).encode_utf8(&mut [0]))
     }
 }
 

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -41,7 +41,7 @@ use crate::{
     strings::CowStr,
     tree::{Tree, TreeIndex},
     Alignment, BlockQuoteKind, CodeBlockKind, ContainerKind, Event, HeadingLevel, LinkType,
-    MetadataBlockKind, Options, Tag, TagEnd,
+    ListType, MetadataBlockKind, Options, Tag, TagEnd,
 };
 
 // Allowing arbitrary depth nested parentheses inside link destinations
@@ -115,7 +115,7 @@ pub(crate) enum ItemBody {
     HtmlBlock,
     BlockQuote(Option<BlockQuoteKind>),
     Container(u8, ContainerKind, CowIndex), // (fence length, specific renderer, descriptor used in renderer)
-    List(bool, u8, u64),                    // is_tight, list character, list start index
+    List(bool, ListType, u64),              // is_tight, list character, list start index
     ListItem(usize),                        // indent level
     FootnoteDefinition(CowIndex),
     MetadataBlock(MetadataBlockKind),
@@ -2320,10 +2320,7 @@ fn body_to_tag_end(body: &ItemBody) -> TagEnd {
         ItemBody::Container(_, kind, _) => TagEnd::ContainerBlock(kind),
         ItemBody::BlockQuote(kind) => TagEnd::BlockQuote(kind),
         ItemBody::HtmlBlock => TagEnd::HtmlBlock,
-        ItemBody::List(_, c, _) => {
-            let is_ordered = c == b'.' || c == b')';
-            TagEnd::List(is_ordered)
-        }
+        ItemBody::List(_, marker_type, _) => TagEnd::List(marker_type.is_ordered()),
         ItemBody::ListItem(_) => TagEnd::Item,
         ItemBody::TableHead => TagEnd::TableHead,
         ItemBody::TableCell => TagEnd::TableCell,
@@ -2400,11 +2397,12 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &mut Allocations<'a>) ->
         ItemBody::IndentCodeBlock => Tag::CodeBlock(CodeBlockKind::Indented),
         ItemBody::Container(_, kind, cow_ix) => Tag::ContainerBlock(kind, allocs.take_cow(cow_ix)),
         ItemBody::BlockQuote(kind) => Tag::BlockQuote(kind),
-        ItemBody::List(_, c, listitem_start) => {
-            if c == b'.' || c == b')' {
-                Tag::List(Some(listitem_start))
-            } else {
-                Tag::List(None)
+        ItemBody::List(tight, marker_type, listitem_start) => {
+            let start = marker_type.is_ordered().then_some(listitem_start);
+            Tag::List {
+                start,
+                marker_type,
+                tight,
             }
         }
         ItemBody::ListItem(_) => Tag::Item,

--- a/pulldown-cmark/src/scanners.rs
+++ b/pulldown-cmark/src/scanners.rs
@@ -28,7 +28,7 @@ use memchr::memchr;
 pub(crate) use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 use crate::{
     entities, parse::HtmlScanGuard, strings::CowStr, Alignment, BlockQuoteKind, HeadingLevel,
-    LinkType,
+    LinkType, ListType,
 };
 
 // sorted for binary search
@@ -312,13 +312,11 @@ impl<'a> LineStart<'a> {
 
     /// Scan a list marker.
     ///
-    /// Return value is the character, the start index, and the indent in spaces.
-    /// For ordered list markers, the character will be one of b'.' or b')'. For
-    /// bullet list markers, it will be one of b'-', b'+', or b'*'.
+    /// Return value is the list type, the start index, and the indent in spaces.
     pub(crate) fn scan_list_marker_with_indent(
         &mut self,
         indent: usize,
-    ) -> Option<(u8, u64, usize)> {
+    ) -> Option<(ListType, u64, usize)> {
         let save = self.clone();
         if self.ix < self.bytes.len() {
             let c = self.bytes[self.ix];
@@ -367,12 +365,21 @@ impl<'a> LineStart<'a> {
         c: u8,
         start: u64,
         mut indent: usize,
-    ) -> Option<(u8, u64, usize)> {
+    ) -> Option<(ListType, u64, usize)> {
         let save = self.clone();
+
+        let ty = match c {
+            b'-' => ListType::HyphenMinus,
+            b'+' => ListType::PlusSign,
+            b'*' => ListType::Asterisk,
+            b'.' => ListType::FullStop,
+            b')' => ListType::RightParenthesis,
+            _ => unreachable!(),
+        };
 
         // skip the rest of the line if it's blank
         if scan_blank_line(&self.bytes[self.ix..]).is_some() {
-            return Some((c, start, indent));
+            return Some((ty, start, indent));
         }
 
         let post_indent = self.scan_space_upto(4);
@@ -381,7 +388,7 @@ impl<'a> LineStart<'a> {
         } else {
             *self = save;
         }
-        Some((c, start, indent))
+        Some((ty, start, indent))
     }
 
     /// Returns Some(is_checked) when a task list marker was found. Resets itself


### PR DESCRIPTION
Add fields `tight` and `marker_type` to `Tag::List` to allow inspecting these two properties of the list. This is a breaking change.

These bits of information cannot otherwise be derived from the Markdown source. In particular, `pulldown-cmark` generates the same sequence of events for `"- > first\n- > second"` and `"- > first\n\n- > second"`, even though the former is tight and the latter is loose.

My use case is for [cmarker.typ](https://github.com/SabrinaJewson/cmarker.typ), which converts Markdown into Typst, and currently does not account for the tightness or looseness of lists for this reason.

The variants of `ListType` were named after the Unicode names of the characters.

There is currently a logical invariant that `start` is `Some` if and only if `marker_type.is_ordered()`. It would be possible to redesign the library such that the type system forbids this; for example:

```rs
enum Tag<'a> {
    // …
    UnorderedList { tight: bool, marker_type: UnorderedListMarkerType },
    OrderedList { start: u64, tight: bool, marker_type: OrderedListMarkerType },
}
enum UnorderedListMarkerType { HyphenMinus, PlusSign, Asterisk }
enum OrderedListMarkerType { FullStop, RightParenthesis }
```

However, in favour of making the change minimally intrusive, I did not use this design.