### PR TITLE
Add an online demo to the book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
-      run: rustup default stable
+      run: |
+        rustup default stable
+        rustup target add wasm32v1-none
     - name: Install mdBook
       run: |
         mkdir mdbook && cd mdbook
@@ -27,6 +29,8 @@ jobs:
       run: |
         rustc prepare-specs.rs
         ./prepare-specs
+        rustc prepare-demo.rs
+        ./prepare-demo
         mdbook build
     - name: Upload Artifact
       uses: actions/upload-pages-artifact@v3.0.1

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Install mdBook
       run: |
         mkdir mdbook && cd mdbook
-        curl -LO 'https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz'
-        tar xf mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz
+        curl -LO 'https://github.com/rust-lang/mdBook/releases/download/v0.5.3/mdbook-v0.5.3-x86_64-unknown-linux-gnu.tar.gz'
+        tar xf mdbook-v0.5.3-x86_64-unknown-linux-gnu.tar.gz
         echo "$(pwd)" >> $GITHUB_PATH
     - name: Prepare book
       working-directory: guide

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f5b01c17f85ee988d832c40e549a64bd89ab2c9f8d8a613bdf5122ae507e294"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dos-fuzzer"
 version = "0.1.0"
 dependencies = [
@@ -1506,6 +1517,14 @@ name = "pulldown-cmark-bench"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "pulldown-cmark",
+]
+
+[[package]]
+name = "pulldown-cmark-demo"
+version = "0.0.0"
+dependencies = [
+ "dlmalloc",
  "pulldown-cmark",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "dlmalloc"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5b01c17f85ee988d832c40e549a64bd89ab2c9f8d8a613bdf5122ae507e294"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,7 @@ version = "0.0.0"
 dependencies = [
  "dlmalloc",
  "pulldown-cmark",
+ "pulldown-cmark-escape",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "bench",
   "dos-fuzzer",
   "fuzz",
+  "guide/demo",
   "pulldown-cmark",
   "pulldown-cmark-escape",
 ]

--- a/guide/.gitignore
+++ b/guide/.gitignore
@@ -2,6 +2,8 @@ book
 src/third_party
 src/specs
 src/doc
+prepare-demo
+prepare-demo.exe
 prepare-specs
 prepare-specs.exe
 deploy

--- a/guide/README.md
+++ b/guide/README.md
@@ -2,4 +2,6 @@ To build this book, install mdbook, then run these commands:
 
     rustc prepare-specs.rs
     ./prepare-specs
+    rustc prepare-demo.rs
+    ./prepare-demo
     mdbook build # or serve

--- a/guide/book.toml
+++ b/guide/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Michael Howell"]
 language = "en"
-multilingual = false
 src = "src"
 title = "pulldown-cmark guide"
 

--- a/guide/demo/Cargo.toml
+++ b/guide/demo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pulldown-cmark-demo"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+pulldown-cmark = { path = "../../pulldown-cmark", default-features = false, features = ["hashbrown", "html"] }
+dlmalloc = { version = "0.2.13", features = ["global"] }

--- a/guide/demo/Cargo.toml
+++ b/guide/demo/Cargo.toml
@@ -9,4 +9,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pulldown-cmark = { path = "../../pulldown-cmark", default-features = false, features = ["hashbrown", "html"] }
+pulldown-cmark-escape = { path = "../../pulldown-cmark-escape" }
 dlmalloc = { version = "0.2.14", features = ["global"] }

--- a/guide/demo/Cargo.toml
+++ b/guide/demo/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pulldown-cmark = { path = "../../pulldown-cmark", default-features = false, features = ["hashbrown", "html"] }
-dlmalloc = { version = "0.2.13", features = ["global"] }
+dlmalloc = { version = "0.2.14", features = ["global"] }

--- a/guide/demo/README.md
+++ b/guide/demo/README.md
@@ -1,0 +1,3 @@
+This crate contains the WASM module that is used in the `demo` page of the book.
+
+Check it with `cargo check --target=wasm32v1-none`.

--- a/guide/demo/src/lib.rs
+++ b/guide/demo/src/lib.rs
@@ -1,0 +1,93 @@
+#![no_std]
+#![expect(clippy::missing_safety_doc)]
+
+use alloc::string::String;
+use core::fmt::Write;
+use dlmalloc::GlobalDlmalloc;
+
+extern crate alloc;
+
+#[global_allocator]
+static ALLOC: GlobalDlmalloc = GlobalDlmalloc;
+
+#[panic_handler]
+#[cfg(target_arch = "wasm32")]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    core::arch::wasm32::unreachable()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn alloc(size: usize, align: usize) -> *mut u8 {
+    let layout = alloc::alloc::Layout::from_size_align(size, align).unwrap();
+    unsafe { alloc::alloc::alloc(layout) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dealloc(ptr: *mut u8, size: usize, align: usize) {
+    let layout = alloc::alloc::Layout::from_size_align(size, align).unwrap();
+    unsafe { alloc::alloc::dealloc(ptr, layout) };
+}
+
+#[repr(C)]
+pub struct FfiString {
+    ptr: *mut u8,
+    len: usize,
+    cap: usize,
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn render(
+    ptr: *mut u8,
+    len: usize,
+    capacity: usize,
+    options: u32,
+    ast: bool,
+    out: *mut FfiString,
+) {
+    let s = unsafe { String::from_raw_parts(ptr, len, capacity) };
+
+    let options = pulldown_cmark::Options::from_bits(options).unwrap();
+    let parser = pulldown_cmark::Parser::new_ext(&s, options);
+
+    let mut res = String::new();
+
+    match ast {
+        false => {
+            pulldown_cmark::html::push_html(&mut res, parser);
+        }
+        true => {
+            res.push_str("<ul>");
+            for event in parser {
+                match event {
+                    pulldown_cmark::Event::End(_) => res.push_str("</ul>"),
+                    _ => res.push_str("<li>"),
+                }
+                write!(HtmlEscape(&mut res), "{event:?}").unwrap();
+                match event {
+                    pulldown_cmark::Event::Start(_) => res.push_str("<ul>"),
+                    _ => res.push_str("</li>"),
+                }
+            }
+            res.push_str("</ul>");
+        }
+    }
+
+    let (ptr, len, cap) = res.into_raw_parts();
+    unsafe { *out = FfiString { ptr, len, cap } };
+}
+
+struct HtmlEscape<'a>(&'a mut String);
+
+impl Write for HtmlEscape<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        for c in s.chars() {
+            match c {
+                '&' => self.0.push_str("&amp;"),
+                '<' => self.0.push_str("&lt;"),
+                '>' => self.0.push_str("&gt;"),
+                c => self.0.push(c),
+            }
+        }
+        Ok(())
+    }
+}

--- a/guide/demo/src/lib.rs
+++ b/guide/demo/src/lib.rs
@@ -80,14 +80,6 @@ struct HtmlEscape<'a>(&'a mut String);
 
 impl Write for HtmlEscape<'_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        for c in s.chars() {
-            match c {
-                '&' => self.0.push_str("&amp;"),
-                '<' => self.0.push_str("&lt;"),
-                '>' => self.0.push_str("&gt;"),
-                c => self.0.push(c),
-            }
-        }
-        Ok(())
+        pulldown_cmark_escape::escape_html_body_text(&mut self.0, s)
     }
 }

--- a/guide/prepare-demo.rs
+++ b/guide/prepare-demo.rs
@@ -1,0 +1,25 @@
+use std::env;
+use std::fs;
+use std::process::Command;
+
+fn main() {
+    env::set_current_dir(env::current_exe().unwrap().parent().unwrap()).unwrap();
+
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "--package=pulldown-cmark-demo",
+            "--target=wasm32v1-none",
+            "--release",
+        ])
+        .env("RUSTFLAGS", "-Clto -Ccodegen-units=1")
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    fs::rename(
+        "../target/wasm32v1-none/release/pulldown_cmark_demo.wasm",
+        "src/demo.wasm",
+    )
+    .unwrap();
+}

--- a/guide/src/.gitignore
+++ b/guide/src/.gitignore
@@ -1,0 +1,1 @@
+/demo.wasm

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 [Guide](index.md)
 - [Cheat sheet](cheat-sheet.md)
+- [Demo](demo.md)
 - [Developer guide](dev/index.md)
   - [Block Structure Parsing](dev/block-parsing.md) 
   - [Inline Processing](dev/inline-processing.md)

--- a/guide/src/demo.md
+++ b/guide/src/demo.md
@@ -1,0 +1,254 @@
+# Demo
+
+<style>
+#form {
+  * {
+    box-sizing: border-box;
+  }
+  .main {
+    textarea {
+      width: 100%;
+    }
+    @media (width >= 600px) {
+      display: flex;
+      flex-flow: row nowrap;
+      > * {
+        flex: 0 0 50%;
+      }
+    }
+    > .output {
+      /* Use sidebar colors for the tabs to get something that is in the right colour scheme. */
+      > .tabs {
+        background: var(--sidebar-bg);
+        color: var(--sidebar-fg);
+        input {
+          display: none;
+        }
+        > label {
+          display: inline-block;
+          padding: 0.3em 0.5em;
+          cursor: pointer;
+        }
+        > label:has(> input:checked) {
+          background: var(--sidebar-fg);
+          color: var(--sidebar-bg);
+        }
+        > label:not(:has(> input:checked)) {
+          &:hover {
+            color: var(--sidebar-active);
+          }
+        }
+      }
+      display: flex;
+      flex-flow: column nowrap;
+      > output {
+        flex: 1 1 auto;
+        > * {
+          display: none;
+          width: 100%;
+          height: 100%;
+        }
+        > pre {
+          margin: 0;
+          white-space: pre-wrap;
+        }
+      }
+      &:has(input[name="format"][value="rendered"]:checked) .rendered {
+        display: block;
+      }
+      &:has(input[name="format"][value="html"]:checked) .html {
+        display: block;
+      }
+      &:has(input[name="format"][value="ast"]:checked) .ast {
+        display: block;
+      }
+    }
+  }
+  fieldset[name="options"] {
+    margin-top: 1em;
+    > div {
+      column-width: 12em;
+      > label {
+        display: block;
+      }
+    }
+  }
+}
+</style>
+
+<form id="form">
+  <div class="main">
+
+<!--
+Create a new HTML block to prevent the default Markdown from being parsed by mdBook as Markdown.
+-->
+<textarea rows="16" name="md" autofocus placeholder="Markdown here!">
+## Try pulldown-cmark
+
+You can try [pulldown-cmark](https://github.com/pulldown-cmark/pulldown-cmark) here.
+This demo is powered by WebAssembly.
+
+1. item one
+2. item two
+   - sublist
+   - sublist
+</textarea>
+
+<div class="output">
+      <div class="tabs">
+        <label><input type="radio" name="format" value="rendered" checked>Rendered</label>
+        <label><input type="radio" name="format" value="html">HTML</label>
+        <label><input type="radio" name="format" value="ast">AST</label>
+      </div>
+      <output>
+        <iframe src="preview.html" class="rendered" frameborder="0" sandbox="allow-same-origin"></iframe>
+        <pre class="html"><code class="language-html"></code></pre>
+        <div class="ast"></div>
+      </output>
+    </div>
+  </div>
+  <button type="button" class="clear">Clear</button>
+  <button type="button" class="permalink">Copy permalink</button>
+  <fieldset name="options">
+    <legend>
+      <a href="https://docs.rs/pulldown-cmark/latest/pulldown_cmark/struct.Options.html"><code>Options</code></a>
+    </legend>
+    <div>
+      <label><input type="checkbox" name="option-1">Tables</label>
+      <label><input type="checkbox" name="option-2">Footnotes</label>
+      <label><input type="checkbox" name="option-3">Strikethrough</label>
+      <label><input type="checkbox" name="option-4">Tasklists</label>
+      <label><input type="checkbox" name="option-5">Smart punctuation</label>
+      <label><input type="checkbox" name="option-6">Heading attributes</label>
+      <label><input type="checkbox" name="option-7">YAML-style metadata blocks</label>
+      <label><input type="checkbox" name="option-8">Pluses-delimited metadata blocks</label>
+      <label><input type="checkbox" name="option-9">Old footnotes</label>
+      <label><input type="checkbox" name="option-10">Math</label>
+      <label><input type="checkbox" name="option-11">GFM</label>
+      <label><input type="checkbox" name="option-12">Definition lists</label>
+      <label><input type="checkbox" name="option-13">Superscript</label>
+      <label><input type="checkbox" name="option-14">Subscript</label>
+      <label><input type="checkbox" name="option-15">Wikilinks</label>
+    </div>
+  </fieldset>
+</form>
+
+<script type="module">
+const { instance } = await WebAssembly.instantiateStreaming(fetch("demo.wasm"));
+
+const form = document.getElementById("form");
+
+// Ensure that the "footnotes" and "old footnotes" options stay in sync (the latter cannot be
+// enabled without the former).
+{
+  const footnotes = form.elements["option-2"];
+  const oldFootnotes = form.elements["option-9"];
+
+  footnotes.addEventListener("input", () => {
+    if (!footnotes.checked) {
+      oldFootnotes.checked = false;
+    }
+  });
+  oldFootnotes.addEventListener("input", () => {
+    if (oldFootnotes.checked) {
+      footnotes.checked = true;
+    }
+  });
+}
+
+// mdBook adds a document-level keydown listener for the arrow keys for page navigation. This
+// interferes with editing the textarea, so we stop propagation of these keydown events.
+form.elements["md"].addEventListener("keydown", e => e.stopPropagation());
+
+const outputRendered = form.querySelector(".rendered").contentDocument.body;
+const outputHtml = form.querySelector(".html > code");
+const outputAst = form.querySelector(".ast");
+
+const readOptions = () => {
+  let options = 0;
+  for (const option of form.elements["options"].elements) {
+    if (!option.checked) {
+      continue;
+    }
+    options |= 1 << parseInt(option.name.slice("option-".length));
+  }
+  return options;
+};
+
+const update = () => {
+  const md = form.elements["md"].value;
+  const format = form.elements["format"].value;
+  const options = readOptions();
+
+  // First, allocate the Markdown as a string inside WASM memory.
+  const mdCap = md.length * 3; // Every UTF-16 code unit results in at most 3 UTF-8 bytes
+  const mdPtr = mdCap === 0 ? 1 : instance.exports.alloc(mdCap, 1);
+  const { written: mdLen } =
+    new TextEncoder().encodeInto(md, new Uint8Array(instance.exports.memory.buffer, mdPtr));
+
+  // Allocate space for a (ptr, len, cap) tuple, where the output string is stored.
+  const out = instance.exports.alloc(4 * 3, 4);
+
+  // Render the Markdown.
+  instance.exports.render(mdPtr, mdLen, mdCap, options, format === "ast", out);
+  const [renderedPtr, renderedLen, renderedCap] =
+    new Uint32Array(instance.exports.memory.buffer, out);
+  instance.exports.dealloc(out, 4 * 3, 4);
+
+  // Convert the rendered content to a Javascript string and deallocate.
+  const rendered = new TextDecoder().decode(
+    new Uint8Array(instance.exports.memory.buffer, renderedPtr, renderedLen),
+  );
+  if (renderedCap !== 0) instance.exports.dealloc(renderedPtr, renderedCap, 1);
+
+  if (format === "rendered") {
+    outputRendered.setHTMLUnsafe(rendered);
+  } else if (format === "html") {
+    outputHtml.textContent = rendered;
+
+    // In highlight.js v11, highlightBlock was renamed to highlightElement. mdBook uses v10 at the
+    // time of writing (mdBook v0.4.43), but to avoid breaking when it updates, we use whichever is
+    // available.
+    (hljs.highlightElement ?? hljs.highlightBlock)(outputHtml);
+  } else if (format === "ast") {
+    outputAst.setHTMLUnsafe(rendered);
+  }
+};
+form.addEventListener("input", update);
+
+form.querySelector("button.clear").addEventListener("click", () => {
+  form.elements["md"].value = "";
+  update();
+});
+
+form.querySelector("button.permalink").addEventListener("click", () => {
+  const url = new URL(location.href);
+  url.search = "";
+  url.searchParams.append("md", form.elements["md"].value);
+  url.searchParams.append("format", form.elements["format"].value);
+  url.searchParams.append("options", readOptions());
+  history.pushState(null, "", url.href);
+  navigator.clipboard.writeText(url.href);
+});
+
+{
+  const params = new URLSearchParams(location.search);
+  const md = params.get("md");
+  const format = params.get("format");
+  const optionsStr = params.get("options");
+  if (md !== null) {
+    form.elements["md"].value = md;
+  }
+  if (format !== null) {
+    form.elements["format"].value = format;
+  }
+  if (optionsStr !== null) {
+    const options = parseInt(optionsStr);
+    for (const option of form.elements["options"].elements) {
+      option.checked = (options & (1 << parseInt(option.name.slice("option-".length)))) !== 0;
+    }
+  }
+}
+
+update();
+</script>

--- a/guide/src/demo.md
+++ b/guide/src/demo.md
@@ -156,10 +156,6 @@ const form = document.getElementById("form");
   });
 }
 
-// mdBook adds a document-level keydown listener for the arrow keys for page navigation. This
-// interferes with editing the textarea, so we stop propagation of these keydown events.
-form.elements["md"].addEventListener("keydown", e => e.stopPropagation());
-
 const outputRendered = form.querySelector(".rendered").contentDocument.body;
 const outputHtml = form.querySelector(".html > code");
 const outputAst = form.querySelector(".ast");

--- a/guide/src/preview.html
+++ b/guide/src/preview.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+	</head>
+	<body>
+	</body>
+</html>


### PR DESCRIPTION
This PR adds a WebAssembly-powered online dingus similar to the [commonmark.js dingus](https://spec.commonmark.org/dingus/) to the book.

It allows viewing the rendered HTML, the raw HTML, as well as the pulldown-cmark AST, which is displayed in `dbg!` fashion as a tree.

A screenshot is below:

<img width="1177" height="849" alt="image" src="https://github.com/user-attachments/assets/424ab07b-14d2-481a-9195-ba68bfb109d8" />

<details><summary>AST view</summary>
<img width="1176" height="1048" alt="image" src="https://github.com/user-attachments/assets/dfa79b80-387f-4b07-ac1f-3d6806375b81" />
</details>

I didn’t put much effort into browser support but it should work on all modern browsers.
