### PR TITLE
Recognize lone CR as a line ending in scan_nextline

### DIFF
--- a/pulldown-cmark/src/scanners.rs
+++ b/pulldown-cmark/src/scanners.rs
@@ -23,7 +23,7 @@
 use alloc::{string::String, vec::Vec};
 use core::char;
 
-use memchr::memchr;
+use memchr::{memchr, memchr2};
 
 pub(crate) use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 use crate::{
@@ -527,7 +527,12 @@ pub(crate) fn scan_blank_line(bytes: &[u8]) -> Option<usize> {
 }
 
 pub(crate) fn scan_nextline(bytes: &[u8]) -> usize {
-    memchr(b'\n', bytes).map_or(bytes.len(), |x| x + 1)
+    // Per CommonMark, a line ending is LF, CRLF, or a lone CR.
+    match memchr2(b'\n', b'\r', bytes) {
+        Some(x) if bytes[x] == b'\r' && bytes.get(x + 1) == Some(&b'\n') => x + 2,
+        Some(x) => x + 1,
+        None => bytes.len(),
+    }
 }
 
 // return: end byte for closing code fence, or None

--- a/pulldown-cmark/tests/html.rs
+++ b/pulldown-cmark/tests/html.rs
@@ -356,3 +356,15 @@ fn issue_819() {
         assert_eq!(expected, s.trim_end_matches('\n'));
     }
 }
+
+// Can't easily use regression.txt due to newline normalization.
+#[test]
+fn issue_1056() {
+    let original = "```\rcode\rblock\r\n```\n";
+    let expected = "<pre><code>code\rblock\n</code></pre>\n";
+
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(original));
+
+    assert_eq!(expected, s);
+}


### PR DESCRIPTION
Fixes #1056.

## Problem

`scanners::scan_nextline()` currently only searches for `\n`, so it handles LF and CRLF but misses lone CR line endings. CommonMark treats LF, CRLF, and lone CR as valid line endings, so inputs containing lone `\r` can be parsed incorrectly.

One concrete failure case from #1056 is the input `"```\rcode\rblock\r\n```\n"`, which currently produces an empty fenced code block because the intermediate lone `\r` is not treated as a line break.

## Fix

Teach `scan_nextline()` to recognize both `\n` and `\r`, while still treating `\r\n` as a single line ending. This keeps the existing LF/CRLF behavior intact and brings lone CR handling in line with the CommonMark definition of a line ending.

## Changes

- `pulldown-cmark/src/scanners.rs`: switch `scan_nextline()` from `memchr()` to `memchr2()` so it recognizes `\n`, `\r\n`, and lone `\r`
- `pulldown-cmark/tests/html.rs`: add a regression test covering the fenced-code example from #1056
- keep the regression in `html.rs` instead of `regression.txt`, since newline normalization makes the lone-CR case hard to express there

## Test results

- `cargo test -q`
- `cargo test -q issue_1056`