### PR TITLE
fix: update the lifetime of returned RefDefs to match the input

### DIFF
--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -321,7 +321,7 @@ impl<'input, CB: ParserCallbacks<'input>> Parser<'input, CB> {
 
     /// Returns a reference to the internal `RefDefs` object, which provides access
     /// to the internal map of reference definitions.
-    pub fn reference_definitions(&self) -> &RefDefs<'_> {
+    pub fn reference_definitions(&self) -> &RefDefs<'input> {
         &self.inner.allocs.refdefs
     }
 
@@ -2230,7 +2230,7 @@ pub struct OffsetIter<'a, CB> {
 
 impl<'a, CB: ParserCallbacks<'a>> OffsetIter<'a, CB> {
     /// Returns a reference to the internal reference definition tracker.
-    pub fn reference_definitions(&self) -> &RefDefs<'_> {
+    pub fn reference_definitions(&self) -> &RefDefs<'a> {
         self.parser.reference_definitions()
     }
 }


### PR DESCRIPTION
- The previous version erroneously ties the *contents* of the RefDefs to the lifetime of the parser/iterator.