### PR TITLE
Feature/export link def

### DIFF
--- a/pulldown-cmark/src/lib.rs
+++ b/pulldown-cmark/src/lib.rs
@@ -114,7 +114,7 @@ use core::fmt::Display;
 
 pub use crate::{
     parse::{
-        BrokenLink, BrokenLinkCallback, DefaultParserCallbacks, OffsetIter, Parser,
+        BrokenLink, BrokenLinkCallback, DefaultParserCallbacks, LinkDef, OffsetIter, Parser,
         ParserCallbacks, RefDefs,
     },
     strings::{CowStr, InlineStr},


### PR DESCRIPTION
- The RefDef struct is exposed, but not its value type (LinkDef). This prevent user code from storing the link definitions in a different data struct or use it in function arguments, for example (without using unsafe).