### PR TITLE
Fix: wikilink with pipe separator leaks child node's next chain into sibling content

### DIFF
--- a/pulldown-cmark/specs/wikilinks.txt
+++ b/pulldown-cmark/specs/wikilinks.txt
@@ -146,13 +146,21 @@ Wikilinks cannot be empty. They will render as-is.
 <p>]] [[]] [[|]] [[|Symbol]] [[</p>
 ````````````````````````````````
 
+If the display text is empty then we omit it from the output anchor.
+
+```````````````````````````````` example_wikilinks
+[[link|]]
+.
+<p><a href="link"></a></p>
+````````````````````````````````
+
 When a wikilink with a pipe separator is nested inside extra brackets, the
 trailing `]]` after the wikilink must appear exactly once.
 
 ```````````````````````````````` example_wikilinks
-[[[[link|]]]]
+[[[[link|display]]]]
 .
-<p>[[<a href="link">]</a>]]</p>
+<p>[[<a href="link">display</a>]]</p>
 ````````````````````````````````
 
 Other interactions wikilinks have with other Markdown syntax:

--- a/pulldown-cmark/specs/wikilinks.txt
+++ b/pulldown-cmark/specs/wikilinks.txt
@@ -146,6 +146,15 @@ Wikilinks cannot be empty. They will render as-is.
 <p>]] [[]] [[|]] [[|Symbol]] [[</p>
 ````````````````````````````````
 
+When a wikilink with a pipe separator is nested inside extra brackets, the
+trailing `]]` after the wikilink must appear exactly once.
+
+```````````````````````````````` example_wikilinks
+[[[[link|]]]]
+.
+<p>[[<a href="link">]</a>]]</p>
+````````````````````````````````
+
 Other interactions wikilinks have with other Markdown syntax:
 
 ```````````````````````````````` example_wikilinks

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -3003,41 +3003,4 @@ text
             n8 / n1.max(1)
         );
     }
-
-    #[test]
-    fn wikilink_pipe_no_duplicate_siblings() {
-        // `[[[[name|]]]]`
-        // The outer `[[` become Text; the inner `[[` form a wikilink.
-        // After the wikilink the remaining `]]` must appear exactly
-        // once as siblings.
-        let input = "[[[[^(\n|]]]]";
-        let events: Vec<_> = Parser::new_ext(input, Options::ENABLE_WIKILINKS)
-            .into_offset_iter()
-            .collect();
-
-        // Collect non-structural events (excluding Start/End wrappers
-        // whose ranges legitimately repeat).  Each Text event's byte
-        // range must appear at most once.
-        let text_ranges: Vec<_> = events
-            .iter()
-            .filter_map(|(e, r)| matches!(e, Event::Text(_)).then_some(r.clone()))
-            .collect();
-
-        let mut seen = HashMap::new();
-        for r in &text_ranges {
-            *seen.entry(r.clone()).or_insert(0usize) += 1;
-        }
-        let dups: Vec<_> = seen.iter().filter(|(_, &c)| c > 1).collect();
-        assert!(
-            dups.is_empty(),
-            "Text events for byte ranges {:?} were emitted more than once.\n\
-             Full event list:\n{}",
-            dups.iter().map(|(r, _)| r).collect::<Vec<_>>(),
-            events
-                .iter()
-                .map(|(e, r)| format!("  {r:6?}  {e:?}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-    }
 }

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -958,6 +958,29 @@ impl<'input> ParserInner<'input> {
                         // break node so passes can actually format
                         // the display text
                         self.tree[body_node].item.start = rest;
+
+                        // Terminate the child chain so it does not extend
+                        // past the closing `]]` into sibling content.
+                        let mut scan = body_node;
+                        loop {
+                            if scan == cur_ix {
+                                // body_node is the closing delimiter node
+                                // (empty display text after `|`); cut here.
+                                self.tree[scan].next = None;
+                                break;
+                            }
+                            match self.tree[scan].next {
+                                Some(n) if n == cur_ix => {
+                                    // scan is the last display-text node;
+                                    // cut before cur_ix.
+                                    self.tree[scan].next = None;
+                                    break;
+                                }
+                                Some(n) => scan = n,
+                                None => break,
+                            }
+                        }
+
                         Some((true, body_node, wikitext))
                     } else {
                         None
@@ -2956,5 +2979,65 @@ text
             Event::End(TagEnd::Paragraph),
         ];
         assert_eq!(&events, &expected);
+    }
+
+    #[test]
+    fn wikilink_no_event_blowup() {
+        // Regression: handle_wikilink reused an existing tree node as
+        // the wikilink's child without terminating that node's `next`
+        // chain.  The `next` chain threaded through the closing `]]`
+        // into the content after the wikilink, so the EventIter
+        // visited that tail content both as children (via child ptr)
+        // and as siblings (via next ptr). Adversarial repeated
+        // `[[|]]` patterns compounded exponentially.
+        let one = "[[[[^(\n|]]]]=]]]]]]]]\n".repeat(1);
+        let eight = "[[[[^(\n|]]]]=]]]]]]]]\n".repeat(8);
+
+        let n1 = Parser::new_ext(&one, Options::ENABLE_WIKILINKS).count();
+        let n8 = Parser::new_ext(&eight, Options::ENABLE_WIKILINKS).count();
+
+        assert!(
+            n8 <= n1 * 20,
+            "Event count should scale linearly with input length; \
+             got {n1} events for 1× and {n8} events for 8× ({}× ratio, expected ≤20×)",
+            n8 / n1.max(1)
+        );
+    }
+
+    #[test]
+    fn wikilink_pipe_no_duplicate_siblings() {
+        // `[[[[name|]]]]`
+        // The outer `[[` become Text; the inner `[[` form a wikilink.
+        // After the wikilink the remaining `]]` must appear exactly
+        // once as siblings.
+        let input = "[[[[^(\n|]]]]";
+        let events: Vec<_> = Parser::new_ext(input, Options::ENABLE_WIKILINKS)
+            .into_offset_iter()
+            .collect();
+
+        // Collect non-structural events (excluding Start/End wrappers
+        // whose ranges legitimately repeat).  Each Text event's byte
+        // range must appear at most once.
+        let text_ranges: Vec<_> = events
+            .iter()
+            .filter_map(|(e, r)| matches!(e, Event::Text(_)).then_some(r.clone()))
+            .collect();
+
+        let mut seen = std::collections::HashMap::new();
+        for r in &text_ranges {
+            *seen.entry(r.clone()).or_insert(0usize) += 1;
+        }
+        let dups: Vec<_> = seen.iter().filter(|(_, &c)| c > 1).collect();
+        assert!(
+            dups.is_empty(),
+            "Text events for byte ranges {:?} were emitted more than once.\n\
+             Full event list:\n{}",
+            dups.iter().map(|(r, _)| r).collect::<Vec<_>>(),
+            events
+                .iter()
+                .map(|(e, r)| format!("  {r:6?}  {e:?}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
     }
 }

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -695,6 +695,7 @@ impl<'input> ParserInner<'input> {
                             .unwrap_or(false)
                     {
                         if let Some(node) = self.handle_wikilink(block_text, cur_ix, prev) {
+                            prev = Some(node);
                             cur = self.tree[node].next;
                             continue;
                         }
@@ -972,22 +973,6 @@ impl<'input> ParserInner<'input> {
                             // break node so passes can actually format
                             // the display text
                             self.tree[body_node].item.start = rest;
-
-                            // Terminate the child chain so it does not extend
-                            // past the closing `]]` into sibling content.
-                            let mut scan = body_node;
-                            loop {
-                                match self.tree[scan].next {
-                                    Some(n) if n == cur_ix => {
-                                        // scan is the last display-text node;
-                                        // cut before cur_ix.
-                                        self.tree[scan].next = None;
-                                        break;
-                                    }
-                                    Some(n) => scan = n,
-                                    None => break,
-                                }
-                            }
 
                             Some((true, body_node, wikitext))
                         } else {

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -953,37 +953,46 @@ impl<'input> ParserInner<'input> {
                         return None;
                     }
                     // [[WikiName|rest]]
-                    let body_node = scan_nodes_to_ix(&self.tree, Some(body_node), rest);
-                    if let Some(body_node) = body_node {
-                        // break node so passes can actually format
-                        // the display text
-                        self.tree[body_node].item.start = rest;
-
-                        // Terminate the child chain so it does not extend
-                        // past the closing `]]` into sibling content.
-                        let mut scan = body_node;
-                        loop {
-                            if scan == cur_ix {
-                                // body_node is the closing delimiter node
-                                // (empty display text after `|`); cut here.
-                                self.tree[scan].next = None;
-                                break;
-                            }
-                            match self.tree[scan].next {
-                                Some(n) if n == cur_ix => {
-                                    // scan is the last display-text node;
-                                    // cut before cur_ix.
-                                    self.tree[scan].next = None;
-                                    break;
-                                }
-                                Some(n) => scan = n,
-                                None => break,
-                            }
-                        }
-
+                    if rest >= end_ix {
+                        // Empty display text: the `|` is immediately followed
+                        // by `]]`. Create a zero-length synthetic node so the
+                        // anchor has no content, rather than accidentally
+                        // capturing the closing `]` delimiter.
+                        let body_node = self.tree.create_node(Item {
+                            start: rest,
+                            end: rest,
+                            body: ItemBody::Text {
+                                backslash_escaped: false,
+                            },
+                        });
                         Some((true, body_node, wikitext))
                     } else {
-                        None
+                        let body_node = scan_nodes_to_ix(&self.tree, Some(body_node), rest);
+                        if let Some(body_node) = body_node {
+                            // break node so passes can actually format
+                            // the display text
+                            self.tree[body_node].item.start = rest;
+
+                            // Terminate the child chain so it does not extend
+                            // past the closing `]]` into sibling content.
+                            let mut scan = body_node;
+                            loop {
+                                match self.tree[scan].next {
+                                    Some(n) if n == cur_ix => {
+                                        // scan is the last display-text node;
+                                        // cut before cur_ix.
+                                        self.tree[scan].next = None;
+                                        break;
+                                    }
+                                    Some(n) => scan = n,
+                                    None => break,
+                                }
+                            }
+
+                            Some((true, body_node, wikitext))
+                        } else {
+                            None
+                        }
                     }
                 }
                 None => {

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -3023,7 +3023,7 @@ text
             .filter_map(|(e, r)| matches!(e, Event::Text(_)).then_some(r.clone()))
             .collect();
 
-        let mut seen = std::collections::HashMap::new();
+        let mut seen = HashMap::new();
         for r in &text_ranges {
             *seen.entry(r.clone()).or_insert(0usize) += 1;
         }

--- a/pulldown-cmark/tests/suite/wikilinks.rs
+++ b/pulldown-cmark/tests/suite/wikilinks.rs
@@ -177,6 +177,16 @@ fn wikilinks_test_15() {
 
 #[test]
 fn wikilinks_test_16() {
+    let original = r##"[[[[link|]]]]
+"##;
+    let expected = r##"<p>[[<a href="link">]</a>]]</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, true, false, false);
+}
+
+#[test]
+fn wikilinks_test_17() {
     let original = r##"[inline link]([[url]])
 "##;
     let expected = r##"<p><a href="%5B%5Burl%5D%5D">inline link</a></p>
@@ -186,7 +196,7 @@ fn wikilinks_test_16() {
 }
 
 #[test]
-fn wikilinks_test_17() {
+fn wikilinks_test_18() {
     let original = r##"[inline link]([[url)]]
 "##;
     let expected = r##"<p><a href="%5B%5Burl">inline link</a>]]</p>
@@ -196,7 +206,7 @@ fn wikilinks_test_17() {
 }
 
 #[test]
-fn wikilinks_test_18() {
+fn wikilinks_test_19() {
     let original = r##"`[[code]]`
 "##;
     let expected = r##"<p><code>[[code]]</code></p>
@@ -206,7 +216,7 @@ fn wikilinks_test_18() {
 }
 
 #[test]
-fn wikilinks_test_19() {
+fn wikilinks_test_20() {
     let original = r##"emphasis **cross [[over** here]]
 "##;
     let expected = r##"<p>emphasis **cross <a href="over**%20here">over** here</a></p>
@@ -216,7 +226,7 @@ fn wikilinks_test_19() {
 }
 
 #[test]
-fn wikilinks_test_20() {
+fn wikilinks_test_21() {
     let original = r##"[[first\|second]]
 "##;
     let expected = r##"<p><a href="first%5C">second</a></p>
@@ -226,7 +236,7 @@ fn wikilinks_test_20() {
 }
 
 #[test]
-fn wikilinks_test_21() {
+fn wikilinks_test_22() {
     let original = r##"[[first&#33;second]]
 "##;
     let expected = r##"<p><a href="first&amp;#33;second">first&amp;#33;second</a></p>

--- a/pulldown-cmark/tests/suite/wikilinks.rs
+++ b/pulldown-cmark/tests/suite/wikilinks.rs
@@ -177,9 +177,9 @@ fn wikilinks_test_15() {
 
 #[test]
 fn wikilinks_test_16() {
-    let original = r##"[[[[link|]]]]
+    let original = r##"[[link|]]
 "##;
-    let expected = r##"<p>[[<a href="link">]</a>]]</p>
+    let expected = r##"<p><a href="link"></a></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false, false, true, false, false);
@@ -187,6 +187,16 @@ fn wikilinks_test_16() {
 
 #[test]
 fn wikilinks_test_17() {
+    let original = r##"[[[[link|display]]]]
+"##;
+    let expected = r##"<p>[[<a href="link">display</a>]]</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, true, false, false);
+}
+
+#[test]
+fn wikilinks_test_18() {
     let original = r##"[inline link]([[url]])
 "##;
     let expected = r##"<p><a href="%5B%5Burl%5D%5D">inline link</a></p>
@@ -196,7 +206,7 @@ fn wikilinks_test_17() {
 }
 
 #[test]
-fn wikilinks_test_18() {
+fn wikilinks_test_19() {
     let original = r##"[inline link]([[url)]]
 "##;
     let expected = r##"<p><a href="%5B%5Burl">inline link</a>]]</p>
@@ -206,7 +216,7 @@ fn wikilinks_test_18() {
 }
 
 #[test]
-fn wikilinks_test_19() {
+fn wikilinks_test_20() {
     let original = r##"`[[code]]`
 "##;
     let expected = r##"<p><code>[[code]]</code></p>
@@ -216,7 +226,7 @@ fn wikilinks_test_19() {
 }
 
 #[test]
-fn wikilinks_test_20() {
+fn wikilinks_test_21() {
     let original = r##"emphasis **cross [[over** here]]
 "##;
     let expected = r##"<p>emphasis **cross <a href="over**%20here">over** here</a></p>
@@ -226,7 +236,7 @@ fn wikilinks_test_20() {
 }
 
 #[test]
-fn wikilinks_test_21() {
+fn wikilinks_test_22() {
     let original = r##"[[first\|second]]
 "##;
     let expected = r##"<p><a href="first%5C">second</a></p>
@@ -236,7 +246,7 @@ fn wikilinks_test_21() {
 }
 
 #[test]
-fn wikilinks_test_22() {
+fn wikilinks_test_23() {
     let original = r##"[[first&#33;second]]
 "##;
     let expected = r##"<p><a href="first&amp;#33;second">first&amp;#33;second</a></p>


### PR DESCRIPTION
handle_wikilink creates a cycle/DAG in the tree when a pipe separator is present, causing exponential event-count growth.

When a wikilink with a pipe separator is parsed (e.g. [[name|display]]), handle_wikilink sets the wikilink node's child pointer to body_node without terminating body_node's next chain. Because body_node is a reused node whose next chain still threads through cur_ix (the closing ] delimiter) and into the content that follows the ]], the EventIter visits those trailing nodes twice: once as children of the wikilink (via the child pointer) and once as siblings (via the wikilink node's own next pointer).

With repeated adversarial patterns like `[[[[^(\n|]]]]=]]]]]]]]\n`, this causes super-polynomial event-count growth effectively hanging the parser. The fix adds a short chain-termination walk starting from body_node that finds and severs the next link that would otherwise reach cur_ix, ensuring the child subtree is properly bounded before the wikilink node is installed into the tree.

This bug was discovered via fuzzing.

This PR contains two tests for the behavior and a fix. There are no regressions against other tests.