### PR TITLE
Fix subtract-overflow panic in handle_wikilink on malformed input

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2879,3 +2879,14 @@ Link must be separated from title by at least one space
 <a href="https://example.com" title="test">a</a>
 <a href="https://example.com" title="test">a</a></p>
 ````````````````````````````````
+
+https://github.com/pulldown-cmark/pulldown-cmark/issues/1108
+
+A malformed image-wrapped wikilink must not underflow when the link body
+starts at or after the closing delimiter.
+
+```````````````````````````````` example_wikilinks
+![[] ]()]]
+.
+<p><img src="" alt="[] " />]]</p>
+````````````````````````````````

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -3003,18 +3003,4 @@ text
             n8 / n1.max(1)
         );
     }
-
-    #[cfg(feature = "html")]
-    #[test]
-    fn wikilink_malformed_no_subtract_overflow() {
-        // Regression for #1108: on malformed image/wikilink input the
-        // wikilink body could begin at or after the closing delimiter, so
-        // `end_ix - start_ix` underflowed (panicking in debug) and later
-        // sliced an inverted range. handle_wikilink must bail early instead.
-        let test_str = " \u{fffd}  ![[] ]()]]";
-
-        let mut buf = String::new();
-        crate::html::push_html(&mut buf, Parser::new_ext(test_str, Options::all()));
-        assert!(!buf.is_empty());
-    }
 }

--- a/pulldown-cmark/src/parse.rs
+++ b/pulldown-cmark/src/parse.rs
@@ -943,6 +943,12 @@ impl<'input> ParserInner<'input> {
             };
             let start_ix = self.tree[body_node].item.start;
             let end_ix = self.tree[cur_ix].item.start;
+            // bail early in case the link is malformed: on some inputs the
+            // body can begin at or after the closing delimiter, which would
+            // otherwise underflow the length below and invert the slice.
+            if end_ix <= start_ix {
+                return None;
+            }
             let wikilink = match scan_wikilink_pipe(
                 block_text,
                 start_ix, // bounded by closing tag
@@ -2996,5 +3002,19 @@ text
              got {n1} events for 1× and {n8} events for 8× ({}× ratio, expected ≤20×)",
             n8 / n1.max(1)
         );
+    }
+
+    #[cfg(feature = "html")]
+    #[test]
+    fn wikilink_malformed_no_subtract_overflow() {
+        // Regression for #1108: on malformed image/wikilink input the
+        // wikilink body could begin at or after the closing delimiter, so
+        // `end_ix - start_ix` underflowed (panicking in debug) and later
+        // sliced an inverted range. handle_wikilink must bail early instead.
+        let test_str = " \u{fffd}  ![[] ]()]]";
+
+        let mut buf = String::new();
+        crate::html::push_html(&mut buf, Parser::new_ext(test_str, Options::all()));
+        assert!(!buf.is_empty());
     }
 }

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3428,3 +3428,13 @@ fn regression_test_214() {
 
     test_markdown_html(original, expected, false, false, false, false, false, false, false);
 }
+
+#[test]
+fn regression_test_215() {
+    let original = r##"![[] ]()]]
+"##;
+    let expected = r##"<p><img src="" alt="[] " />]]</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, true, false, false);
+}


### PR DESCRIPTION
`FirstPass::handle_wikilink` computes `start_ix` (the wikilink body node's start) and `end_ix` (the current node's start), then uses `end_ix - start_ix` as a length and slices `&block_text[start_ix..end_ix]`. On some malformed image/wikilink inputs the body node begins at or after the closing delimiter, so `start_ix > end_ix`: the subtraction underflows and panics (`attempt to subtract with overflow` in debug builds), and the slice range is inverted.

This adds an early bail-out — matching the function's documented "bail early in case the link is malformed" behavior and its existing `return None;` idiom — right after both indices are computed:

```rust
if end_ix <= start_ix {
    return None;
}
```

### Test

Added a regression test that runs the reproducer from the issue (`" \u{fffd}  ![[] ]()]]"`) through `Parser::new_ext(.., Options::all())` and `html::push_html`, asserting it no longer panics. Without the guard this input panics with the subtraction overflow; with it, the full test suite (1212 tests) passes.

Closes #1108.
