### PR TITLE
Fix panic on HTML block ending with a lone carriage return

### DIFF
--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -1602,7 +1602,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 body: ItemBody::SynthesizeText(cow_ix),
             });
         }
-        if self.text.as_bytes()[end - 2] == b'\r' {
+        let bytes = self.text.as_bytes();
+        if end >= start + 2 && bytes[end - 1] == b'\n' && bytes[end - 2] == b'\r' {
             // Normalize CRLF to LF
             self.tree.append(Item {
                 start,

--- a/pulldown-cmark/tests/errors.rs
+++ b/pulldown-cmark/tests/errors.rs
@@ -143,3 +143,8 @@ fn test_bad_slice_unicode() {
 fn test_simd_wrapping_shr_issue_651() {
     parse("`````````````````````````````````x`");
 }
+
+#[test]
+fn test_html_block_lone_cr_issue_1112() {
+    parse("<!S\r:");
+}


### PR DESCRIPTION
Fixes #1112

`append_html_line` normalizes a trailing CRLF into two separate `Html` items by checking `bytes[end - 2] == b'\r'`. That check assumes the line ends with a two-byte `\r\n`, but `scan_nextline` also treats a lone `\r` as a line ending (per CommonMark), so `end - 2` can point at the previous line's carriage return. On input like `<!S\r:` the second line's slice is built with `start = 4` and `end = 3`, which panics with "byte range starts at 4 but ends at 3".

The guard now only splits when the line actually ends with `\r\n` (`bytes[end - 1] == b'\n' && bytes[end - 2] == b'\r'`), and requires at least two bytes so the indexing can't underflow. Added the fuzzer input as a regression test in `tests/errors.rs`.
