### PR TITLE
Keep the task list marker as literal text when item content is a setext heading

### DIFF
--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2909,8 +2909,9 @@ d ~~x ~[x](https://x)~ x~~
 https://github.com/pulldown-cmark/pulldown-cmark/issues/1115
 
 A task list marker is only valid when the list item content is a
-paragraph. When the paragraph becomes a setext heading, the marker
-must not be emitted inside the heading.
+paragraph. When the paragraph becomes a setext heading, the task-list
+interpretation is canceled and the marker bytes are kept as literal
+text instead of being emitted inside the heading.
 
 ```````````````````````````````` example
 - [ ] a
@@ -2918,7 +2919,7 @@ must not be emitted inside the heading.
 .
 <ul>
 <li>
-<h2>a</h2>
+<h2>[ ] a</h2>
 </li>
 </ul>
 ````````````````````````````````
@@ -2941,7 +2942,7 @@ x</p>
 </ul>
 ````````````````````````````````
 
-Heading attributes still apply when the marker is dropped (#1115).
+Heading attributes still apply when the marker is kept as text (#1115).
 
 ```````````````````````````````` example
 - [x] a {#id}
@@ -2949,7 +2950,21 @@ Heading attributes still apply when the marker is dropped (#1115).
 .
 <ul>
 <li>
-<h2 id="id">a</h2>
+<h2 id="id">[x] a</h2>
+</li>
+</ul>
+````````````````````````````````
+
+Only the separating whitespace is kept with the marker text, so a
+backslash escape right after it still resolves normally (#1115).
+
+```````````````````````````````` example
+- [ ] \*a\*
+  -
+.
+<ul>
+<li>
+<h2>[ ] *a*</h2>
 </li>
 </ul>
 ````````````````````````````````

--- a/pulldown-cmark/specs/regression.txt
+++ b/pulldown-cmark/specs/regression.txt
@@ -2905,3 +2905,51 @@ d ~~x ~[x](https://x)~ x~~
 <p>c ~x ~~<a href="https://x">x</a>~~ x~</p>
 <p>d ~~x <sub><a href="https://x">x</a></sub> x~~</p>
 ````````````````````````````````
+
+https://github.com/pulldown-cmark/pulldown-cmark/issues/1115
+
+A task list marker is only valid when the list item content is a
+paragraph. When the paragraph becomes a setext heading, the marker
+must not be emitted inside the heading.
+
+```````````````````````````````` example
+- [ ] a
+  -
+.
+<ul>
+<li>
+<h2>a</h2>
+</li>
+</ul>
+````````````````````````````````
+
+A task list marker on an earlier paragraph is kept when a *later*
+block in the same item becomes a setext heading (#1115).
+
+```````````````````````````````` example
+- [ ] x
+
+  y
+  -
+.
+<ul>
+<li>
+<p><input disabled="" type="checkbox"/>
+x</p>
+<h2>y</h2>
+</li>
+</ul>
+````````````````````````````````
+
+Heading attributes still apply when the marker is dropped (#1115).
+
+```````````````````````````````` example
+- [x] a {#id}
+  -
+.
+<ul>
+<li>
+<h2 id="id">a</h2>
+</li>
+</ul>
+````````````````````````````````

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -884,11 +884,21 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         );
 
         // A task list marker is only valid when the list item's content is a
-        // paragraph. If this paragraph turned out to be a setext heading, drop
-        // the leading marker so it doesn't end up inside the heading (#1115).
+        // paragraph. If this paragraph turned out to be a setext heading, the
+        // marker would render inside the heading (#1115). Cancel the task-list
+        // interpretation and keep the marker's `[ ]`/`[x]` bytes as literal
+        // text (the node already spans them) rather than silently dropping it.
         if let Some(child_ix) = self.tree[node_ix].child {
             if let ItemBody::TaskListMarker(_) = self.tree[child_ix].item.body {
-                self.tree[node_ix].child = self.tree[child_ix].next;
+                // Grow the span across the whitespace that separated the marker
+                // from the text, so that spacing is preserved too. Scan only the
+                // whitespace run (not up to the next node) so a following
+                // backslash escape isn't pulled into the literal marker text.
+                let end = self.tree[child_ix].item.end;
+                self.tree[child_ix].item.end = end + scan_whitespace_no_nl(&bytes[end..]);
+                self.tree[child_ix].item.body = ItemBody::Text {
+                    backslash_escaped: false,
+                };
             }
         }
 

--- a/pulldown-cmark/src/firstpass.rs
+++ b/pulldown-cmark/src/firstpass.rs
@@ -883,6 +883,15 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             attrs.map(|attrs| self.allocs.allocate_heading(attrs)),
         );
 
+        // A task list marker is only valid when the list item's content is a
+        // paragraph. If this paragraph turned out to be a setext heading, drop
+        // the leading marker so it doesn't end up inside the heading (#1115).
+        if let Some(child_ix) = self.tree[node_ix].child {
+            if let ItemBody::TaskListMarker(_) = self.tree[child_ix].item.body {
+                self.tree[node_ix].child = self.tree[child_ix].next;
+            }
+        }
+
         Some(ix + n)
     }
 

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3465,7 +3465,7 @@ fn regression_test_217() {
 "##;
     let expected = r##"<ul>
 <li>
-<h2>a</h2>
+<h2>[ ] a</h2>
 </li>
 </ul>
 "##;
@@ -3499,7 +3499,22 @@ fn regression_test_219() {
 "##;
     let expected = r##"<ul>
 <li>
-<h2 id="id">a</h2>
+<h2 id="id">[x] a</h2>
+</li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, false, false, false, false, false);
+}
+
+#[test]
+fn regression_test_220() {
+    let original = r##"- [ ] \*a\*
+  -
+"##;
+    let expected = r##"<ul>
+<li>
+<h2>[ ] *a*</h2>
 </li>
 </ul>
 "##;

--- a/pulldown-cmark/tests/suite/regression.rs
+++ b/pulldown-cmark/tests/suite/regression.rs
@@ -3457,3 +3457,52 @@ d ~~x ~[x](https://x)~ x~~
 
     test_markdown_html(original, expected, false, false, false, true, false, false, false, false, false);
 }
+
+#[test]
+fn regression_test_217() {
+    let original = r##"- [ ] a
+  -
+"##;
+    let expected = r##"<ul>
+<li>
+<h2>a</h2>
+</li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, false, false, false, false, false);
+}
+
+#[test]
+fn regression_test_218() {
+    let original = r##"- [ ] x
+
+  y
+  -
+"##;
+    let expected = r##"<ul>
+<li>
+<p><input disabled="" type="checkbox"/>
+x</p>
+<h2>y</h2>
+</li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, false, false, false, false, false);
+}
+
+#[test]
+fn regression_test_219() {
+    let original = r##"- [x] a {#id}
+  -
+"##;
+    let expected = r##"<ul>
+<li>
+<h2 id="id">a</h2>
+</li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false, false, false, false, false, false, false);
+}


### PR DESCRIPTION
Fixes #1115.

With `ENABLE_TASKLISTS`, a task list marker is appended as the first child of the item's paragraph before the paragraph is parsed. If that paragraph turns out to be a setext heading (`  -` underline), the body is rewritten to `Heading` but the marker stayed inside, producing `<h2><input type="checkbox">a</h2>`.

Per GFM a task list marker is only valid when the item content is a paragraph, so drop the leading marker when the paragraph becomes a setext heading. A marker on an earlier paragraph (when only a later block becomes a heading) is unaffected.

Regression tests cover the reported case, the earlier-paragraph case, and heading attributes.

Used AI assistance on this; I reviewed and tested it.
